### PR TITLE
Add offer model and management endpoints

### DIFF
--- a/app/Http/Controllers/Admin/OfferController.php
+++ b/app/Http/Controllers/Admin/OfferController.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\BaseController;
+use App\Models\Offer;
+use App\Models\Product;
+use App\Models\ProductStock;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class OfferController extends BaseController
+{
+    public function index(): JsonResponse
+    {
+        $offers = Offer::with(['product', 'variant', 'giftProduct'])->get();
+        return response()->json($offers);
+    }
+
+    public function show(Offer $offer): JsonResponse
+    {
+        $offer->load(['product', 'variant', 'giftProduct']);
+        return response()->json($offer);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'product_id' => ['required', 'exists:products,id'],
+            'variant_id' => ['nullable', 'exists:product_stocks,id'],
+            'quantity' => ['required', 'integer', 'min:1'],
+            'bundle_price' => ['required', 'numeric', 'min:0'],
+            'gift_product_id' => ['nullable', 'exists:products,id'],
+            'is_active' => ['sometimes', 'boolean'],
+        ]);
+
+        if (!empty($data['is_active'])) {
+            $this->validateStock($data['product_id'], $data['variant_id'] ?? null, $data['quantity']);
+        }
+
+        $offer = Offer::create($data);
+
+        return response()->json($offer, 201);
+    }
+
+    public function update(Request $request, Offer $offer): JsonResponse
+    {
+        $data = $request->validate([
+            'product_id' => ['sometimes', 'exists:products,id'],
+            'variant_id' => ['nullable', 'exists:product_stocks,id'],
+            'quantity' => ['sometimes', 'integer', 'min:1'],
+            'bundle_price' => ['sometimes', 'numeric', 'min:0'],
+            'gift_product_id' => ['nullable', 'exists:products,id'],
+            'is_active' => ['sometimes', 'boolean'],
+        ]);
+
+        $isActivating = isset($data['is_active']) && $data['is_active'];
+        $quantity = $data['quantity'] ?? $offer->quantity;
+        $productId = $data['product_id'] ?? $offer->product_id;
+        $variantId = array_key_exists('variant_id', $data) ? $data['variant_id'] : $offer->variant_id;
+
+        if ($isActivating) {
+            $this->validateStock($productId, $variantId, $quantity);
+        }
+
+        $offer->update($data);
+
+        return response()->json($offer);
+    }
+
+    public function destroy(Offer $offer): JsonResponse
+    {
+        $offer->delete();
+        return response()->json([], 204);
+    }
+
+    protected function validateStock($productId, $variantId, $quantity): void
+    {
+        if ($variantId) {
+            $stock = ProductStock::find($variantId);
+            if (!$stock || $stock->qty < $quantity) {
+                abort(422, 'Insufficient stock for the variant.');
+            }
+        } else {
+            $product = Product::find($productId);
+            if (!$product || $product->current_stock < $quantity) {
+                abort(422, 'Insufficient stock for the product.');
+            }
+        }
+    }
+}

--- a/app/Http/Controllers/Vendor/OfferController.php
+++ b/app/Http/Controllers/Vendor/OfferController.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Http\Controllers\Vendor;
+
+use App\Http\Controllers\BaseController;
+use App\Models\Offer;
+use App\Models\Product;
+use App\Models\ProductStock;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class OfferController extends BaseController
+{
+    public function index(): JsonResponse
+    {
+        $offers = Offer::whereHas('product', function ($query) {
+            $query->where('user_id', Auth::id());
+        })->with(['product', 'variant', 'giftProduct'])->get();
+
+        return response()->json($offers);
+    }
+
+    public function show(Offer $offer): JsonResponse
+    {
+        $this->authorizeOffer($offer);
+        $offer->load(['product', 'variant', 'giftProduct']);
+        return response()->json($offer);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'product_id' => ['required', 'exists:products,id'],
+            'variant_id' => ['nullable', 'exists:product_stocks,id'],
+            'quantity' => ['required', 'integer', 'min:1'],
+            'bundle_price' => ['required', 'numeric', 'min:0'],
+            'gift_product_id' => ['nullable', 'exists:products,id'],
+            'is_active' => ['sometimes', 'boolean'],
+        ]);
+
+        $product = Product::where('id', $data['product_id'])->where('user_id', Auth::id())->firstOrFail();
+        if (!empty($data['variant_id'])) {
+            ProductStock::where('id', $data['variant_id'])->where('product_id', $product->id)->firstOrFail();
+        }
+
+        if (!empty($data['is_active'])) {
+            $this->validateStock($product->id, $data['variant_id'] ?? null, $data['quantity']);
+        }
+
+        $offer = Offer::create($data);
+
+        return response()->json($offer, 201);
+    }
+
+    public function update(Request $request, Offer $offer): JsonResponse
+    {
+        $this->authorizeOffer($offer);
+
+        $data = $request->validate([
+            'product_id' => ['sometimes', 'exists:products,id'],
+            'variant_id' => ['nullable', 'exists:product_stocks,id'],
+            'quantity' => ['sometimes', 'integer', 'min:1'],
+            'bundle_price' => ['sometimes', 'numeric', 'min:0'],
+            'gift_product_id' => ['nullable', 'exists:products,id'],
+            'is_active' => ['sometimes', 'boolean'],
+        ]);
+
+        $productId = $data['product_id'] ?? $offer->product_id;
+        $product = Product::where('id', $productId)->where('user_id', Auth::id())->firstOrFail();
+
+        $variantId = array_key_exists('variant_id', $data) ? $data['variant_id'] : $offer->variant_id;
+        if ($variantId) {
+            ProductStock::where('id', $variantId)->where('product_id', $product->id)->firstOrFail();
+        }
+
+        $isActivating = isset($data['is_active']) && $data['is_active'];
+        $quantity = $data['quantity'] ?? $offer->quantity;
+        if ($isActivating) {
+            $this->validateStock($product->id, $variantId, $quantity);
+        }
+
+        $offer->update($data);
+
+        return response()->json($offer);
+    }
+
+    public function destroy(Offer $offer): JsonResponse
+    {
+        $this->authorizeOffer($offer);
+        $offer->delete();
+        return response()->json([], 204);
+    }
+
+    protected function authorizeOffer(Offer $offer): void
+    {
+        if ($offer->product->user_id !== Auth::id()) {
+            abort(403, 'Unauthorized');
+        }
+    }
+
+    protected function validateStock($productId, $variantId, $quantity): void
+    {
+        if ($variantId) {
+            $stock = ProductStock::find($variantId);
+            if (!$stock || $stock->qty < $quantity) {
+                abort(422, 'Insufficient stock for the variant.');
+            }
+        } else {
+            $product = Product::find($productId);
+            if (!$product || $product->current_stock < $quantity) {
+                abort(422, 'Insufficient stock for the product.');
+            }
+        }
+    }
+}

--- a/app/Models/Offer.php
+++ b/app/Models/Offer.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Offer extends Model
+{
+    protected $fillable = [
+        'product_id',
+        'variant_id',
+        'quantity',
+        'bundle_price',
+        'gift_product_id',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'product_id' => 'integer',
+        'variant_id' => 'integer',
+        'quantity' => 'integer',
+        'bundle_price' => 'float',
+        'gift_product_id' => 'integer',
+        'is_active' => 'boolean',
+    ];
+
+    public function product(): BelongsTo
+    {
+        return $this->belongsTo(Product::class);
+    }
+
+    public function variant(): BelongsTo
+    {
+        return $this->belongsTo(ProductStock::class, 'variant_id');
+    }
+
+    public function giftProduct(): BelongsTo
+    {
+        return $this->belongsTo(Product::class, 'gift_product_id');
+    }
+}

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -217,6 +217,11 @@ class Product extends Model
         return $this->hasMany(ProductStock::class);
     }
 
+    public function offers(): HasMany
+    {
+        return $this->hasMany(Offer::class);
+    }
+
     public function clearanceSale(): HasOne
     {
         return $this->hasOne(StockClearanceProduct::class, 'product_id');

--- a/app/Models/ProductStock.php
+++ b/app/Models/ProductStock.php
@@ -3,8 +3,12 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class ProductStock extends Model
 {
-    //
+    public function offers(): HasMany
+    {
+        return $this->hasMany(Offer::class, 'variant_id');
+    }
 }

--- a/database/migrations/2024_05_17_000000_create_offers_table.php
+++ b/database/migrations/2024_05_17_000000_create_offers_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('offers', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('product_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('variant_id')->nullable()->constrained('product_stocks')->nullOnDelete();
+            $table->integer('quantity');
+            $table->decimal('bundle_price', 8, 2);
+            $table->foreignId('gift_product_id')->nullable()->constrained('products')->nullOnDelete();
+            $table->boolean('is_active')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('offers');
+    }
+};

--- a/routes/admin/routes.php
+++ b/routes/admin/routes.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Admin\ExpenseTransactionReportController;
 use App\Http\Controllers\Admin\Promotion\ClearanceSaleController;
 use App\Http\Controllers\Admin\Promotion\ClearanceSalePrioritySetupController;
 use App\Http\Controllers\Admin\Promotion\ClearanceSaleVendorOfferController;
+use App\Http\Controllers\Admin\OfferController;
 use App\Http\Controllers\Admin\Settings\AddonActivationController;
 use App\Http\Controllers\Admin\Settings\FirebaseOTPVerificationController;
 use App\Http\Controllers\FirebaseController;
@@ -1148,6 +1149,16 @@ Route::group(['prefix' => 'admin', 'as' => 'admin.', 'middleware' => ['admin', '
             Route::post('feature-status-update', 'updateFeatureStatus')->name('feature-status-update');
             Route::post('update' . '/{id}', 'update');
             Route::post('delete', 'delete')->name('delete');
+        });
+    });
+
+    Route::group(['prefix' => 'offers', 'as' => 'offers.'], function () {
+        Route::controller(OfferController::class)->group(function () {
+            Route::get('/', 'index')->name('index');
+            Route::post('/', 'store')->name('store');
+            Route::get('{offer}', 'show')->name('show');
+            Route::put('{offer}', 'update')->name('update');
+            Route::delete('{offer}', 'destroy')->name('destroy');
         });
     });
 

--- a/routes/vendor/routes.php
+++ b/routes/vendor/routes.php
@@ -38,6 +38,7 @@ use App\Http\Controllers\Vendor\POS\POSOrderController;
 use App\Http\Controllers\Vendor\Product\ProductController;
 use App\Http\Controllers\Vendor\ProfileController;
 use App\Http\Controllers\Vendor\Promotion\ClearanceSaleController;
+use App\Http\Controllers\Vendor\OfferController;
 use App\Http\Controllers\Vendor\RefundController;
 use App\Http\Controllers\Vendor\ReviewController;
 use App\Http\Controllers\Vendor\Shipping\CategoryShippingCostController;
@@ -351,6 +352,16 @@ Route::group(['middleware' => ['maintenance_mode', 'actch:admin_panel']], functi
 
             Route::controller(SystemController::class)->group(function () {
                 Route::get('/get-order-data', 'getOrderData')->name('get-order-data');
+            });
+
+            Route::group(['prefix' => 'offers', 'as' => 'offers.'], function () {
+                Route::controller(OfferController::class)->group(function () {
+                    Route::get('/', 'index')->name('index');
+                    Route::post('/', 'store')->name('store');
+                    Route::get('{offer}', 'show')->name('show');
+                    Route::put('{offer}', 'update')->name('update');
+                    Route::delete('{offer}', 'destroy')->name('destroy');
+                });
             });
 
             Route::group(['prefix' => 'report', 'as' => 'report.'], function () {


### PR DESCRIPTION
## Summary
- add Offer model and migration with product, variant, quantity, bundle price, optional gift product and status
- expose admin and vendor CRUD controllers and routes for offers
- validate stock levels before allowing activation

## Testing
- `composer install --no-interaction --no-progress` *(fails: kreait/firebase-php requires php ~8.3, ext-sodium missing)*


------
https://chatgpt.com/codex/tasks/task_e_68a2555a85ec83269963d39d640eba28