### PR TITLE
feat(pos): add basic offer handling

### DIFF
--- a/app/Http/Controllers/Admin/POS/POSController.php
+++ b/app/Http/Controllers/Admin/POS/POSController.php
@@ -432,6 +432,29 @@ class POSController extends BaseController
         return array_merge($customerCartData[$cartName], $cartItemData);
     }
 
+    public function getActiveOffers(Request $request): JsonResponse
+    {
+        $product = $this->productRepo->getFirstWhere(
+            params: ['id' => $request['product_id']],
+            relations: ['clearanceSale' => function ($query) {
+                return $query->active();
+            }]
+        );
+
+        $offers = [];
+        if ($product?->clearanceSale) {
+            $offers[] = [
+                'id' => $product->clearanceSale->id,
+                'label' => translate('offer'),
+                'bundle_quantity' => 1,
+                'gift_product_id' => null,
+                'offer_price' => getProductPriceByType(product: $product, type: 'discounted_unit_price', result: 'value', price: $product['unit_price'], from: 'panel'),
+            ];
+        }
+
+        return response()->json(['offers' => $offers]);
+    }
+
     public function getSearchedProductsView(Request $request): JsonResponse
     {
         $products = $this->productRepo->getListWithScope(

--- a/app/Http/Controllers/Vendor/POS/CartController.php
+++ b/app/Http/Controllers/Vendor/POS/CartController.php
@@ -135,6 +135,10 @@ class CartController extends BaseController
         }
         $price = $product['unit_price'];
         $discount = getProductPriceByType(product: $product, type: 'discounted_amount', result: 'value', price: $price);
+        if ($request->filled('offer_price')) {
+            $price = $request['offer_price'];
+            $discount = 0;
+        }
         $cartData = session($cartId);
         if ($cartId && session()->has($cartId) && count($cartData) > 0) {
             foreach ($cartData as $key => $cartItem) {
@@ -182,6 +186,14 @@ class CartController extends BaseController
                     unset($cartData[$key]);
                     $cartData[] = $cartItem;
                     session([$cartId => $cartData]);
+                    if ($request->filled('gift_product_id')) {
+                        $giftProduct = $this->productRepo->getFirstWhere(params: ['id' => $request['gift_product_id']], relations: ['clearanceSale' => function ($query) {
+                            return $query->active();
+                        }]);
+                        if ($giftProduct) {
+                            $this->cartService->addCartDataOnSession(product: $giftProduct, quantity: 1, price: 0, discount: 0, variant: null, variations: []);
+                        }
+                    }
                     $getCurrentCustomerData = $this->getCustomerDataFromSessionForPOS();
                     $summaryData = array_merge($this->POSService->getSummaryData(), $getCurrentCustomerData);
                     $cartItems = $this->getCartData(cartName: $cartId);
@@ -225,6 +237,14 @@ class CartController extends BaseController
             variant: $variant,
             variations: $variations
         );
+        if ($request->filled('gift_product_id')) {
+            $giftProduct = $this->productRepo->getFirstWhere(params: ['id' => $request['gift_product_id']], relations: ['clearanceSale' => function ($query) {
+                return $query->active();
+            }]);
+            if ($giftProduct) {
+                $this->cartService->addCartDataOnSession(product: $giftProduct, quantity: 1, price: 0, discount: 0, variant: null, variations: []);
+            }
+        }
         $cartItems = $this->getCartData(cartName: $cartId);
         return response()->json([
             'data' => $sessionData,

--- a/app/Http/Controllers/Vendor/POS/POSController.php
+++ b/app/Http/Controllers/Vendor/POS/POSController.php
@@ -464,6 +464,29 @@ class POSController extends BaseController
         return array_merge($customerCartData[$cartName], $cartItemData);
     }
 
+    public function getActiveOffers(Request $request): JsonResponse
+    {
+        $product = $this->productRepo->getFirstWhere(
+            params: ['id' => $request['product_id']],
+            relations: ['clearanceSale' => function ($query) {
+                return $query->active();
+            }]
+        );
+
+        $offers = [];
+        if ($product?->clearanceSale) {
+            $offers[] = [
+                'id' => $product->clearanceSale->id,
+                'label' => translate('offer'),
+                'bundle_quantity' => 1,
+                'gift_product_id' => null,
+                'offer_price' => getProductPriceByType(product: $product, type: 'discounted_unit_price', result: 'value', price: $product['unit_price'], from: 'panel'),
+            ];
+        }
+
+        return response()->json(['offers' => $offers]);
+    }
+
     public function getSearchedProductsView(Request $request): JsonResponse
     {
         $products = $this->productRepo->getListWithScope(

--- a/public/assets/back-end/js/vendor/pos-script.js
+++ b/public/assets/back-end/js/vendor/pos-script.js
@@ -726,12 +726,46 @@ function quickView(product_id) {
             renderRippleEffect();
             closeAlertMessage();
             $("#quick-view").modal("show");
+            fetchActiveOffers(product_id);
         },
         complete: function () {
             $("#loading").fadeOut();
         },
     });
 }
+
+function fetchActiveOffers(productId) {
+    $.get({
+        url: $("#route-vendor-pos-get-active-offers").data("url"),
+        data: { product_id: productId },
+        success: function (response) {
+            let section = $(".offer-section");
+            let container = section.find(".offer-buttons");
+            container.empty();
+            if (response.offers && response.offers.length) {
+                section.removeClass("d-none");
+                response.offers.forEach(function (offer) {
+                    container.append(
+                        `<button type="button" class="btn btn-outline--primary btn-sm offer-btn" data-bundle="${offer.bundle_quantity}" data-gift="${offer.gift_product_id}" data-price="${offer.offer_price}">${offer.label} (${offer.bundle_quantity})</button>`
+                    );
+                });
+            } else {
+                section.addClass("d-none");
+            }
+        },
+    });
+}
+
+$(document).on("click", ".offer-btn", function () {
+    let bundle = $(this).data("bundle");
+    let gift = $(this).data("gift");
+    let price = $(this).data("price");
+    let form = $("#add-to-cart-form");
+    form.find("input[name='quantity']").val(bundle);
+    form.find("input[name='offer_price']").val(price);
+    form.find("input[name='gift_product_id']").val(gift);
+    addToCart();
+});
 
 function getVariantForAlreadyInCart(event = null) {
     let current_val = parseFloat($(".in-cart-quantity-field").val());
@@ -945,6 +979,7 @@ function addToCart(form_id = "add-to-cart-form") {
                         : "";
                     removeFromCart();
                     basicFunctionalityForCartSummary();
+                    $("#" + form_id).find("input[name='offer_price'], input[name='gift_product_id']").val("");
                     return false;
                 } else if (data.data == 0) {
                     Swal.fire({
@@ -980,6 +1015,7 @@ function addToCart(form_id = "add-to-cart-form") {
                 $("#search").val("");
                 posUpdateQuantityFunctionality();
                 removeFromCart();
+                $("#" + form_id).find("input[name='offer_price'], input[name='gift_product_id']").val("");
             },
             complete: function () {
                 $("#loading").fadeOut();

--- a/resources/views/admin-views/pos/index.blade.php
+++ b/resources/views/admin-views/pos/index.blade.php
@@ -161,6 +161,7 @@
 <span id="route-admin-pos-empty-cart" data-url="{{ route('admin.pos.empty-cart') }}"></span>
 <span id="route-admin-pos-update-quantity" data-url="{{ route('admin.pos.update-quantity') }}"></span>
 <span id="route-admin-pos-get-variant-price" data-url="{{ route('admin.pos.get-variant-price') }}"></span>
+<span id="route-admin-pos-get-active-offers" data-url="{{ route('admin.pos.get-active-offers') }}"></span>
 <span id="route-admin-pos-change-cart-editable" data-url="{{ route('admin.pos.change-cart').'/?cart_id=:value' }}"></span>
 
 <span id="message-cart-word" data-text="{{ translate('cart') }}"></span>

--- a/resources/views/admin-views/pos/partials/_quick-view.blade.php
+++ b/resources/views/admin-views/pos/partials/_quick-view.blade.php
@@ -48,6 +48,11 @@
             <div class="mt-3">
                 <form id="add-to-cart-form" class="add-to-cart-details-form">
                     @csrf
+                    <div class="offer-section d-none mb-3">
+                        <div class="d-flex gap-2 flex-wrap offer-buttons"></div>
+                    </div>
+                    <input type="hidden" name="offer_price" value="">
+                    <input type="hidden" name="gift_product_id" value="">
                     <div class="details">
                         <div class="d-flex flex-wrap gap-3 mb-3">
                             <div

--- a/resources/views/vendor-views/pos/index.blade.php
+++ b/resources/views/vendor-views/pos/index.blade.php
@@ -162,6 +162,7 @@
     <span id="route-vendor-pos-empty-cart" data-url="{{ route('vendor.pos.cart-empty') }}"></span>
     <span id="route-vendor-pos-update-quantity" data-url="{{ route('vendor.pos.quantity-update') }}"></span>
     <span id="route-vendor-pos-get-variant-price" data-url="{{ route('vendor.pos.get-variant-price') }}"></span>
+    <span id="route-vendor-pos-get-active-offers" data-url="{{ route('vendor.pos.get-active-offers') }}"></span>
     <span id="route-vendor-pos-change-cart-editable" data-url="{{ route('vendor.pos.change-cart').'/?cart_id=:value' }}"></span>
 
     <span id="message-cart-word" data-text="{{ translate('cart') }}"></span>

--- a/resources/views/vendor-views/pos/partials/_quick-view.blade.php
+++ b/resources/views/vendor-views/pos/partials/_quick-view.blade.php
@@ -68,6 +68,12 @@
                 <form id="add-to-cart-form" class="add-to-cart-details-form">
                     @csrf
 
+                    <div class="offer-section d-none mb-3">
+                        <div class="d-flex gap-2 flex-wrap offer-buttons"></div>
+                    </div>
+                    <input type="hidden" name="offer_price" value="">
+                    <input type="hidden" name="gift_product_id" value="">
+
                     <div class="details">
                         <div class="d-flex flex-wrap gap-3 mb-3">
                             <div

--- a/routes/admin/routes.php
+++ b/routes/admin/routes.php
@@ -154,6 +154,7 @@ Route::group(['prefix' => 'admin', 'as' => 'admin.', 'middleware' => ['admin', '
             Route::post('coupon-discount', 'getCouponDiscount')->name('coupon-discount');
             Route::get('quick-view', 'getQuickView')->name('quick-view');
             Route::get('search-product', 'getSearchedProductsView')->name('search-product');
+            Route::get('active-offers', 'getActiveOffers')->name('get-active-offers');
         });
 
         Route::controller(CartController::class)->group(function () {

--- a/routes/vendor/routes.php
+++ b/routes/vendor/routes.php
@@ -100,6 +100,7 @@ Route::group(['middleware' => ['maintenance_mode', 'actch:admin_panel']], functi
                     Route::post(POS::COUPON_DISCOUNT[URI], 'getCouponDiscount')->name('coupon-discount');
                     Route::get(POS::QUICK_VIEW[URI], 'getQuickView')->name('quick-view');
                     Route::get(POS::SEARCH[URI], 'getSearchedProductsView')->name('search-product');
+                    Route::get('active-offers', 'getActiveOffers')->name('get-active-offers');
                 });
                 Route::controller(CartController::class)->group(function () {
                     Route::post(Cart::VARIANT[URI], 'getVariantPrice')->name('get-variant-price');


### PR DESCRIPTION
## Summary
- fetch active offers for POS products
- display offer buttons and apply to cart with optional gifts

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a255869e108326ae9565b0005b9843