### PR TITLE
Ensure clearance offers respect stock and POS scope

### DIFF
--- a/app/Models/StockClearanceProduct.php
+++ b/app/Models/StockClearanceProduct.php
@@ -56,10 +56,19 @@ class StockClearanceProduct extends Model
 
     public function scopeActive($query)
     {
+        $isPosRequest = request()->is('admin/pos*') || request()->is('vendor/pos*') || request()->is('api/*/pos*');
+
+        if (!$isPosRequest) {
+            return $query->whereRaw('0 = 1');
+        }
+
         return $query
             ->where(['is_active' => 1])
             ->whereIn('added_by', ['admin', 'vendor'])
-        ->CheckConfig();
+            ->whereHas('product', function ($q) {
+                return $q->where('current_stock', '>', 0);
+            })
+            ->CheckConfig();
     }
 
     public function scopeCheckConfig($query): void

--- a/tests/Unit/StockClearanceOfferTest.php
+++ b/tests/Unit/StockClearanceOfferTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\StockClearanceProduct;
+use Tests\TestCase;
+
+class StockClearanceOfferTest extends TestCase
+{
+    public function test_scope_blocks_non_pos_requests(): void
+    {
+        $this->app['request']->server->set('REQUEST_URI', '/not-pos');
+        $sql = StockClearanceProduct::query()->active()->toSql();
+        $this->assertStringContainsString('0 = 1', $sql);
+    }
+
+    public function test_scope_checks_product_stock_and_allows_pos_requests(): void
+    {
+        $this->app['request']->server->set('REQUEST_URI', 'admin/pos/test');
+        $sql = StockClearanceProduct::query()->active()->toSql();
+        $this->assertStringNotContainsString('0 = 1', $sql);
+        $this->assertStringContainsString('current_stock', $sql);
+    }
+}


### PR DESCRIPTION
## Summary
- restrict stock clearance offers to POS endpoints and ensure they only apply to in-stock products
- validate inventory before activating clearance offers
- add tests covering POS-only scope and stock checks

## Testing
- `php artisan test tests/Unit/StockClearanceOfferTest.php` *(fails: Failed opening required '/workspace/sharqia/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68a2558d473083268abc30b478afea62