### PR TITLE
Add offer bundle pricing for cart

### DIFF
--- a/app/Http/Controllers/RestAPI/v1/CartController.php
+++ b/app/Http/Controllers/RestAPI/v1/CartController.php
@@ -101,7 +101,8 @@ class CartController extends Controller
                     }
                 }
 
-                $data['discount'] = getProductPriceByType(product: $data['product'], type: 'discounted_amount', result: 'value', price: $data['price']);
+                $basePrice = $data['offer_id'] ? $data['bundle_price'] : $data['price'];
+                $data['discount'] = getProductPriceByType(product: $data['product'], type: 'discounted_amount', result: 'value', price: $basePrice);
                 unset($data['product']['variation']);
                 return $data;
             });

--- a/app/Models/Cart.php
+++ b/app/Models/Cart.php
@@ -62,6 +62,8 @@ class Cart extends Model
         'updated_at' => 'datetime',
         'shipping_cost' => 'float',
         'is_guest' => 'integer',
+        'offer_id' => 'integer',
+        'bundle_price' => 'float',
     ];
 
     protected $fillable = [
@@ -89,6 +91,8 @@ class Cart extends Model
         'shipping_cost',
         'shipping_type',
         'is_guest',
+        'offer_id',
+        'bundle_price',
     ];
 
     public function cartShipping(): HasOne

--- a/app/Utils/CartManager.php
+++ b/app/Utils/CartManager.php
@@ -69,7 +69,8 @@ class CartManager
                 return $query->where(['is_checked' => 1]);
             })
             ->get()?->each(function ($item) {
-                $item['discount'] = getProductPriceByType(product: $item['product'], type: 'discounted_amount', result: 'value', price: $item['price']);
+                $basePrice = $item['offer_id'] ? $item['bundle_price'] : $item['price'];
+                $item['discount'] = getProductPriceByType(product: $item['product'], type: 'discounted_amount', result: 'value', price: $basePrice);
             });
     }
 
@@ -95,7 +96,8 @@ class CartManager
                 return $query->where(['is_checked' => 1]);
             })
             ->get()?->each(function ($item) {
-                $item['discount'] = getProductPriceByType(product: $item['product'], type: 'discounted_amount', result: 'value', price: $item['price']);
+                $basePrice = $item['offer_id'] ? $item['bundle_price'] : $item['price'];
+                $item['discount'] = getProductPriceByType(product: $item['product'], type: 'discounted_amount', result: 'value', price: $basePrice);
             });
     }
 
@@ -119,7 +121,8 @@ class CartManager
                 return $query->where(['is_checked' => 1]);
             })
             ->get()?->each(function ($item) {
-                $item['discount'] = getProductPriceByType(product: $item['product'], type: 'discounted_amount', result: 'value', price: $item['price']);
+                $basePrice = $item['offer_id'] ? $item['bundle_price'] : $item['price'];
+                $item['discount'] = getProductPriceByType(product: $item['product'], type: 'discounted_amount', result: 'value', price: $basePrice);
             })->groupBy('cart_group_id');
     }
 
@@ -139,7 +142,8 @@ class CartManager
                 return $query->where(['is_checked' => 1]);
             })
             ->get()?->each(function ($item) {
-                $item['discount'] = getProductPriceByType(product: $item['product'], type: 'discounted_amount', result: 'value', price: $item['price']);
+                $basePrice = $item['offer_id'] ? $item['bundle_price'] : $item['price'];
+                $item['discount'] = getProductPriceByType(product: $item['product'], type: 'discounted_amount', result: 'value', price: $basePrice);
             });
     }
 
@@ -303,7 +307,8 @@ class CartManager
         $total = 0;
         if (!empty($cart)) {
             foreach ($cart as $item) {
-                $product_subtotal = $item['price'] * $item['quantity'];
+                $basePrice = $item['offer_id'] ? $item['bundle_price'] : $item['price'];
+                $product_subtotal = $basePrice * $item['quantity'];
                 $total += $product_subtotal;
             }
         }
@@ -315,8 +320,9 @@ class CartManager
         $total = 0;
         if (!empty($cart)) {
             foreach ($cart as $item) {
-                $discount = getProductPriceByType(product: $item['product'], type: 'discounted_amount', result: 'value', price: $item['price']);
-                $productSubtotal = ($item['price'] - $discount) * $item['quantity'];
+                $basePrice = $item['offer_id'] ? $item['bundle_price'] : $item['price'];
+                $discount = getProductPriceByType(product: $item['product'], type: 'discounted_amount', result: 'value', price: $basePrice);
+                $productSubtotal = ($basePrice - $discount) * $item['quantity'];
                 $total += $productSubtotal;
             }
         }
@@ -328,7 +334,8 @@ class CartManager
         $total = 0;
         if (!empty($cart)) {
             foreach ($cart as $item) {
-                $product_subtotal = ($item['price'] * $item['quantity']) + ($item['tax'] * $item['quantity']);
+                $basePrice = $item['offer_id'] ? $item['bundle_price'] : $item['price'];
+                $product_subtotal = ($basePrice * $item['quantity']) + ($item['tax'] * $item['quantity']);
                 $total += $product_subtotal;
             }
         }
@@ -348,8 +355,9 @@ class CartManager
         if (!empty($cart)) {
             foreach ($cart as $item) {
                 $tax = $item['tax_model'] == 'include' ? 0 : $item['tax'];
-                $discount = getProductPriceByType(product: $item['product'], type: 'discounted_amount', result: 'value', price: $item['price']);
-                $productSubtotal = ($item['price'] + $tax - $discount) * $item['quantity'];
+                $basePrice = $item['offer_id'] ? $item['bundle_price'] : $item['price'];
+                $discount = getProductPriceByType(product: $item['product'], type: 'discounted_amount', result: 'value', price: $basePrice);
+                $productSubtotal = ($basePrice + $tax - $discount) * $item['quantity'];
                 $total += $productSubtotal;
             }
             $total += $shippingCost;
@@ -367,8 +375,9 @@ class CartManager
         $total = 0;
         if (!empty($cart)) {
             foreach ($cart as $item) {
-                $discount = getProductPriceByType(product: $item['product'], type: 'discounted_amount', result: 'value', price: $item['price']);
-                $productSubtotal = ($item['price'] - $discount) * $item['quantity'];
+                $basePrice = $item['offer_id'] ? $item['bundle_price'] : $item['price'];
+                $discount = getProductPriceByType(product: $item['product'], type: 'discounted_amount', result: 'value', price: $basePrice);
+                $productSubtotal = ($basePrice - $discount) * $item['quantity'];
                 $total += $productSubtotal;
             }
         }
@@ -383,7 +392,8 @@ class CartManager
         if (!empty($cart)) {
             foreach ($cart as $item) {
                 $tax = $item['tax_model'] == 'include' ? 0 : $item['tax'];
-                $product_subtotal = ($item['price'] * $item['quantity'])
+                $basePrice = $item['offer_id'] ? $item['bundle_price'] : $item['price'];
+                $product_subtotal = ($basePrice * $item['quantity'])
                     + ($tax * $item['quantity'])
                     - $item['discount'] * $item['quantity'];
                 $total += $product_subtotal;
@@ -404,7 +414,8 @@ class CartManager
         if (!empty($cart)) {
             foreach ($cart as $item) {
                 $tax = $item['tax_model'] == 'include' ? 0 : $item['tax'];
-                $productSubtotal = ($item['price'] * $item['quantity']) + ($tax * $item['quantity']) - $item['discount'] * $item['quantity'];
+                $basePrice = $item['offer_id'] ? $item['bundle_price'] : $item['price'];
+                $productSubtotal = ($basePrice * $item['quantity']) + ($tax * $item['quantity']) - $item['discount'] * $item['quantity'];
                 $total += $productSubtotal;
             }
         }
@@ -501,7 +512,8 @@ class CartManager
         }
 
         $tax = Helpers::tax_calculation(product: $product, price: $price, tax: $product['tax'], tax_type: 'percent');
-        $getProductDiscount = getProductPriceByType(product: $product, type: 'discounted_amount', result: 'value', price: $price);
+        $basePrice = $request['offer_id'] ? $request['bundle_price'] : $price;
+        $getProductDiscount = getProductPriceByType(product: $product, type: 'discounted_amount', result: 'value', price: $basePrice);
 
         $cartArray += [
             'customer_id' => ($user == 'offline' ? $guestId : $user->id),
@@ -509,6 +521,8 @@ class CartManager
             'product_type' => $product['product_type'],
             'quantity' => $request['quantity'],
             'price' => $price,
+            'bundle_price' => $basePrice,
+            'offer_id' => $request['offer_id'] ?? null,
             'tax' => $tax,
             'tax_model' => $product->tax_model,
             'discount' => $getProductDiscount,
@@ -544,7 +558,7 @@ class CartManager
 
         if ($request['buy_now'] == 1) {
             $calculateTax = $product['tax_model'] == 'include' ? 0 : ($tax * $request['quantity']);
-            $productTotalPrice = ($price * $request['quantity']) + $calculateTax - ($getProductDiscount * $request['quantity']);
+            $productTotalPrice = ($basePrice * $request['quantity']) + $calculateTax - ($getProductDiscount * $request['quantity']);
             $verifyStatus = OrderManager::checkSingleProductMinimumOrderAmountVerify(request: $request, product: $product, totalAmount: $productTotalPrice);
             if ($verifyStatus['status'] == 0) {
                 return ['status' => 0, 'message' => $verifyStatus['message']];
@@ -656,7 +670,8 @@ class CartManager
         }
 
         $tax = Helpers::tax_calculation(product: $product, price: $price, tax: $product['tax'], tax_type: 'percent');
-        $getProductDiscount = getProductPriceByType(product: $product, type: 'discounted_amount', result: 'value', price: $price);
+        $basePrice = $request['offer_id'] ? $request['bundle_price'] : $price;
+        $getProductDiscount = getProductPriceByType(product: $product, type: 'discounted_amount', result: 'value', price: $basePrice);
         $cartArray = [
             'customer_id' => $customerId,
             'product_id' => $request['id'],
@@ -667,6 +682,8 @@ class CartManager
             'variant' => $request['variant_key'],
             'quantity' => $request['quantity'],
             'price' => $price,
+            'bundle_price' => $basePrice,
+            'offer_id' => $request['offer_id'] ?? null,
             'tax' => $tax,
             'tax_model' => $product['tax_model'],
             'discount' => $getProductDiscount,
@@ -701,7 +718,7 @@ class CartManager
 
         if ($request['buy_now'] == 1) {
             $calculateTax = $product['tax_model'] == 'include' ? 0 : ($tax * $request['quantity']);
-            $productTotalPrice = ($price * $request['quantity']) + $calculateTax - ($getProductDiscount * $request['quantity']);
+            $productTotalPrice = ($basePrice * $request['quantity']) + $calculateTax - ($getProductDiscount * $request['quantity']);
             $verifyStatus = OrderManager::checkSingleProductMinimumOrderAmountVerify(request: $request, product: $product, totalAmount: $productTotalPrice);
             if ($verifyStatus['status'] == 0) {
                 return ['status' => 0, 'message' => $verifyStatus['message']];

--- a/app/Utils/OrderManager.php
+++ b/app/Utils/OrderManager.php
@@ -62,7 +62,8 @@ class OrderManager
         }
 
         foreach ($cart as $item) {
-            $subTotal += $item->price * $item->quantity;
+            $basePrice = $item->offer_id ? $item->bundle_price : $item->price;
+            $subTotal += $basePrice * $item->quantity;
             $totalDiscountOnProduct += $item->discount * $item->quantity;
         }
 
@@ -399,14 +400,16 @@ class OrderManager
         $onlyProductTotalAmount = 0;
         if ($coupon->coupon_type == 'first_order') {
             foreach ($cartList as $cartItem) {
-                $onlyProductTotalAmount += ($cartItem['price'] - $cartItem['discount']) * $cartItem['quantity'];
+                $basePrice = $cartItem['offer_id'] ? $cartItem['bundle_price'] : $cartItem['price'];
+                $onlyProductTotalAmount += ($basePrice - $cartItem['discount']) * $cartItem['quantity'];
             }
         }
 
         if ($coupon->coupon_type == 'discount_on_purchase') {
             foreach ($cartList as $cartItem) {
                 if (($coupon->seller_id == '0') || (is_null($coupon->seller_id) && $cartItem['seller_is'] == 'admin') || ($coupon->seller_id == $cartItem['seller_id'] && $cartItem['seller_is'] == 'seller')) {
-                    $onlyProductTotalAmount += ($cartItem['price'] - $cartItem['discount']) * $cartItem['quantity'];
+                    $basePrice = $cartItem['offer_id'] ? $cartItem['bundle_price'] : $cartItem['price'];
+                    $onlyProductTotalAmount += ($basePrice - $cartItem['discount']) * $cartItem['quantity'];
                 }
             }
         }
@@ -429,7 +432,8 @@ class OrderManager
         } elseif ($coupon->coupon_type == 'free_delivery') {
             foreach ($cartList as $cartItem) {
                 if (($coupon->seller_id == '0') || (is_null($coupon->seller_id) && $cartItem['seller_is'] == 'admin') || ($coupon->seller_id == $cartItem['seller_id'] && $cartItem['seller_is'] == 'seller')) {
-                    $onlyProductTotalAmount += ($cartItem['price'] - $cartItem['discount']) * $cartItem['quantity'];
+                    $basePrice = $cartItem['offer_id'] ? $cartItem['bundle_price'] : $cartItem['price'];
+                    $onlyProductTotalAmount += ($basePrice - $cartItem['discount']) * $cartItem['quantity'];
                 }
             }
             foreach ($cartList->groupBy('cart_group_id') as $cartGroupItem) {
@@ -495,7 +499,8 @@ class OrderManager
             foreach ($cartListGroup as $cartListGroupKey => $cartList) {
                 if ($cartListGroupKey == $groupId) {
                     foreach ($cartList as $cartItem) {
-                        $onlyProductTotalAmount += ($cartItem['price'] - $cartItem['discount']) * $cartItem['quantity'];
+                        $basePrice = $cartItem['offer_id'] ? $cartItem['bundle_price'] : $cartItem['price'];
+                        $onlyProductTotalAmount += ($basePrice - $cartItem['discount']) * $cartItem['quantity'];
                     }
                 }
             }
@@ -504,11 +509,12 @@ class OrderManager
         if ($discountOnPurchaseCoupon) {
             foreach ($cartListGroup as $cartListGroupKey => $cartList) {
                 if ($cartListGroupKey == $groupId) {
-                    foreach ($cartList as $cartItem) {
-                        if (($coupon->seller_id == '0') || (is_null($coupon->seller_id) && $cartItem['seller_is'] == 'admin') || ($coupon->seller_id == $cartItem['seller_id'] && $cartItem['seller_is'] == 'seller')) {
-                            $onlyProductTotalAmount += ($cartItem['price'] - $cartItem['discount']) * $cartItem['quantity'];
-                        }
-                    }
+            foreach ($cartList as $cartItem) {
+                if (($coupon->seller_id == '0') || (is_null($coupon->seller_id) && $cartItem['seller_is'] == 'admin') || ($coupon->seller_id == $cartItem['seller_id'] && $cartItem['seller_is'] == 'seller')) {
+                    $basePrice = $cartItem['offer_id'] ? $cartItem['bundle_price'] : $cartItem['price'];
+                    $onlyProductTotalAmount += ($basePrice - $cartItem['discount']) * $cartItem['quantity'];
+                }
+            }
                 }
             }
         }
@@ -830,8 +836,9 @@ class OrderManager
                 $product['storage_path'] = $product['digital_file_ready_storage_type'] ?? 'public';
             }
 
-            $price = $cartSingleItem['tax_model'] == 'include' ? $cartSingleItem['price'] - $cartSingleItem['tax'] : $cartSingleItem['price'];
-            $productDiscount = getProductPriceByType(product: $product, type: 'discounted_amount', result: 'value', price: $cartSingleItem['price']);
+            $basePrice = $cartSingleItem['offer_id'] ? $cartSingleItem['bundle_price'] : $cartSingleItem['price'];
+            $price = $cartSingleItem['tax_model'] == 'include' ? $basePrice - $cartSingleItem['tax'] : $basePrice;
+            $productDiscount = getProductPriceByType(product: $product, type: 'discounted_amount', result: 'value', price: $basePrice);
             $orderDetails = [
                 'order_id' => $orderId,
                 'product_id' => $cartSingleItem['product_id'],
@@ -1269,6 +1276,8 @@ class OrderManager
                             $cart['customer_id'] = $user->id ?? 0;
                             $cart['quantity'] = $orderProductQuantity;
                             $cart['price'] = $price;
+                            $cart['bundle_price'] = $price;
+                            $cart['offer_id'] = null;
                             $cart['tax'] = $tax;
                             $cart['tax_model'] = $product->tax_model;
                             $cart['slug'] = $product->slug;

--- a/database/migrations/2024_05_01_000000_add_offer_fields_to_carts_table.php
+++ b/database/migrations/2024_05_01_000000_add_offer_fields_to_carts_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('carts', function (Blueprint $table) {
+            $table->unsignedBigInteger('offer_id')->nullable()->after('is_guest');
+            $table->float('bundle_price')->default(0)->after('offer_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('carts', function (Blueprint $table) {
+            $table->dropColumn(['offer_id', 'bundle_price']);
+        });
+    }
+};

--- a/tests/Unit/OfferBundlePriceTest.php
+++ b/tests/Unit/OfferBundlePriceTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Utils\CartManager;
+use App\Utils\OrderManager;
+
+test('order summary uses bundle price', function () {
+    $cart = collect([
+        (object) [
+            'price' => 100,
+            'bundle_price' => 80,
+            'offer_id' => 1,
+            'quantity' => 2,
+            'discount' => 5,
+            'seller_id' => 1,
+        ],
+    ]);
+
+    $summary = OrderManager::getOrderSummaryBeforePlaceOrder($cart, 0);
+
+    expect($summary['order_total'])->toBe((80 * 2) - (5 * 2));
+});
+
+test('cart totals use bundle price', function () {
+    $cart = [
+        [
+            'price' => 100,
+            'bundle_price' => 50,
+            'offer_id' => 1,
+            'quantity' => 3,
+            'tax' => 10,
+            'discount' => 0,
+            'tax_model' => 'exclude',
+        ],
+    ];
+
+    expect(CartManager::cart_total($cart))->toBe(150);
+    expect(CartManager::cart_total_with_tax($cart))->toBe(180);
+});


### PR DESCRIPTION
## Summary
- track offer bundles in cart items with offer_id and bundle_price fields
- update cart totals and order summaries to use bundle pricing and apply discounts afterward
- ensure taxes use original unit price and add tests for bundle pricing calculations

## Testing
- `php -l app/Models/Cart.php`
- `php -l app/Utils/CartManager.php`
- `php -l app/Utils/OrderManager.php`
- `php -l app/Http/Controllers/RestAPI/v1/CartController.php`
- `php -l database/migrations/2024_05_01_000000_add_offer_fields_to_carts_table.php`
- `php -l tests/Unit/OfferBundlePriceTest.php`
- `composer install --no-interaction --no-progress --prefer-dist --ignore-platform-reqs` (failed: curl error 56 while downloading from api.github.com)
- `./vendor/bin/phpunit tests/Unit/OfferBundlePriceTest.php` (failed: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68a2558af06483268e1a175217f72190