### PR TITLE
Alias offer controllers for admin and vendor routes

### DIFF
--- a/routes/admin/routes.php
+++ b/routes/admin/routes.php
@@ -6,7 +6,7 @@ use App\Http\Controllers\Admin\ExpenseTransactionReportController;
 use App\Http\Controllers\Admin\Promotion\ClearanceSaleController;
 use App\Http\Controllers\Admin\Promotion\ClearanceSalePrioritySetupController;
 use App\Http\Controllers\Admin\Promotion\ClearanceSaleVendorOfferController;
-use App\Http\Controllers\Admin\OfferController;
+use App\Http\Controllers\Admin\OfferController as AdminOfferController;
 use App\Http\Controllers\Admin\Settings\AddonActivationController;
 use App\Http\Controllers\Admin\Settings\FirebaseOTPVerificationController;
 use App\Http\Controllers\FirebaseController;
@@ -14,7 +14,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\SharedController;
 use App\Http\Controllers\Admin\ReportController;
 use App\Http\Controllers\Admin\POS\POSController;
-use App\Http\Controllers\Admin\POS\OfferController;
+use App\Http\Controllers\Admin\POS\OfferController as POSOfferController;
 use App\Http\Controllers\Admin\ProfileController;
 use App\Http\Controllers\Admin\ChattingController;
 use App\Http\Controllers\Admin\POS\CartController;
@@ -178,7 +178,7 @@ Route::group(['prefix' => 'admin', 'as' => 'admin.', 'middleware' => ['admin', '
             Route::any('view-hold-orders', 'getAllHoldOrdersView')->name('view-hold-orders');
         });
 
-        Route::controller(OfferController::class)->group(function () {
+        Route::controller(POSOfferController::class)->group(function () {
             Route::get('offers', 'index')->name('offers.index');
             Route::post('offers', 'store')->name('offers.store');
             Route::post('offers/status', 'updateStatus')->name('offers.status');
@@ -1161,7 +1161,7 @@ Route::group(['prefix' => 'admin', 'as' => 'admin.', 'middleware' => ['admin', '
     });
 
     Route::group(['prefix' => 'offers', 'as' => 'offers.'], function () {
-        Route::controller(OfferController::class)->group(function () {
+        Route::controller(AdminOfferController::class)->group(function () {
             Route::get('/', 'index')->name('index');
             Route::post('/', 'store')->name('store');
             Route::get('{offer}', 'show')->name('show');

--- a/routes/vendor/routes.php
+++ b/routes/vendor/routes.php
@@ -35,11 +35,11 @@ use App\Http\Controllers\Vendor\NotificationController;
 use App\Http\Controllers\Vendor\POS\CartController;
 use App\Http\Controllers\Vendor\POS\POSController;
 use App\Http\Controllers\Vendor\POS\POSOrderController;
-use App\Http\Controllers\Vendor\POS\OfferController;
+use App\Http\Controllers\Vendor\POS\OfferController as POSOfferController;
 use App\Http\Controllers\Vendor\Product\ProductController;
 use App\Http\Controllers\Vendor\ProfileController;
 use App\Http\Controllers\Vendor\Promotion\ClearanceSaleController;
-use App\Http\Controllers\Vendor\OfferController;
+use App\Http\Controllers\Vendor\OfferController as VendorOfferController;
 use App\Http\Controllers\Vendor\RefundController;
 use App\Http\Controllers\Vendor\ReviewController;
 use App\Http\Controllers\Vendor\Shipping\CategoryShippingCostController;
@@ -122,7 +122,7 @@ Route::group(['middleware' => ['maintenance_mode', 'actch:admin_panel']], functi
                     Route::any(POSOrder::HOLD_ORDERS[URI], 'getAllHoldOrdersView')->name('view-hold-orders');
                 });
 
-                Route::controller(OfferController::class)->group(function () {
+                Route::controller(POSOfferController::class)->group(function () {
                     Route::get('offers', 'index')->name('offers.index');
                     Route::post('offers', 'store')->name('offers.store');
                     Route::post('offers/status', 'updateStatus')->name('offers.status');
@@ -363,7 +363,7 @@ Route::group(['middleware' => ['maintenance_mode', 'actch:admin_panel']], functi
             });
 
             Route::group(['prefix' => 'offers', 'as' => 'offers.'], function () {
-                Route::controller(OfferController::class)->group(function () {
+                Route::controller(VendorOfferController::class)->group(function () {
                     Route::get('/', 'index')->name('index');
                     Route::post('/', 'store')->name('store');
                     Route::get('{offer}', 'show')->name('show');


### PR DESCRIPTION
## Summary
- alias admin and POS offer controllers in admin routes
- alias vendor and POS offer controllers in vendor routes

## Testing
- ⚠️ `php artisan route:clear` (failed: Failed opening required 'vendor/autoload.php')
- ⚠️ `php artisan migrate` (failed: Failed opening required 'vendor/autoload.php')

------
https://chatgpt.com/codex/tasks/task_e_68a25b1cca14832684fea2a274a10842