### PR TITLE
Add governorate coverage selection for vendors

### DIFF
--- a/app/Http/Controllers/Admin/Vendor/VendorController.php
+++ b/app/Http/Controllers/Admin/Vendor/VendorController.php
@@ -39,6 +39,7 @@ use App\Contracts\Repositories\WithdrawRequestRepositoryInterface;
 use App\Contracts\Repositories\OrderTransactionRepositoryInterface;
 use App\Contracts\Repositories\StockClearanceSetupRepositoryInterface;
 use App\Contracts\Repositories\StockClearanceProductRepositoryInterface;
+use App\Models\Governorate;
 
 class VendorController extends BaseController
 {
@@ -88,7 +89,8 @@ class VendorController extends BaseController
 
     public function getAddView(Request $request): View
     {
-        return view('admin-views.vendor.add-new-vendor');
+        $governorates = Governorate::all();
+        return view('admin-views.vendor.add-new-vendor', compact('governorates'));
     }
 
     public function add(Request $request): JsonResponse
@@ -96,6 +98,9 @@ class VendorController extends BaseController
         $vendor = $this->vendorRepo->add(data: $this->vendorService->getAddData($request));
         $this->shopRepo->add($this->shopService->getAddShopDataForRegistration(request: $request, vendorId: $vendor['id']));
         $this->vendorWalletRepo->add($this->vendorService->getInitialWalletData(vendorId: $vendor['id']));
+        if ($request->has('governorates')) {
+            $vendor->governorate_coverages()->sync($request['governorates']);
+        }
         $data = [
             'vendorName' => $request['f_name'],
             'status' => 'pending',
@@ -380,11 +385,18 @@ class VendorController extends BaseController
 
     public function getSettingListTabView(Request $request, $seller, $id): View
     {
-        return view('admin-views.vendor.view.setting', compact('seller'));
+        $governorates = Governorate::all();
+        $seller->load('governorate_coverages');
+        return view('admin-views.vendor.view.setting', compact('seller', 'governorates'));
     }
 
     public function updateSetting(Request $request, $id): RedirectResponse
     {
+        if ($request->has('governorates')) {
+            $seller = $this->vendorRepo->getFirstWhere(params: ['id' => $id]);
+            $seller->governorate_coverages()->sync($request['governorates']);
+            ToastMagic::success(translate('coverage_governorates_updated'));
+        }
         if ($request->has('commission')) {
             request()->validate([
                 'commission' => 'required|numeric|min:1',

--- a/app/Models/Governorate.php
+++ b/app/Models/Governorate.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Governorate extends Model
+{
+    protected $fillable = ['name_ar'];
+
+    public function sellers(): BelongsToMany
+    {
+        return $this->belongsToMany(Seller::class, 'seller_governorate_coverages', 'governorate_id', 'seller_id');
+    }
+}

--- a/app/Models/Seller.php
+++ b/app/Models/Seller.php
@@ -6,6 +6,7 @@ use App\Traits\StorageTrait;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Carbon;
@@ -112,6 +113,11 @@ class Seller extends Authenticatable
             ->where(['coupon_bearer' => 'seller', 'status' => 1])
             ->whereDate('start_date', '<=', date('Y-m-d'))
             ->whereDate('expire_date', '>=', date('Y-m-d'));
+    }
+
+    public function governorate_coverages(): BelongsToMany
+    {
+        return $this->belongsToMany(Governorate::class, 'seller_governorate_coverages', 'seller_id', 'governorate_id');
     }
 
     public function getImageFullUrlAttribute(): array

--- a/database/migrations/2025_08_01_000000_create_governorates_table.php
+++ b/database/migrations/2025_08_01_000000_create_governorates_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('governorates', function (Blueprint $table) {
+            $table->id();
+            $table->string('name_ar');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('governorates');
+    }
+};

--- a/database/migrations/2025_08_01_000100_create_seller_governorate_coverages_table.php
+++ b/database/migrations/2025_08_01_000100_create_seller_governorate_coverages_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('seller_governorate_coverages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('seller_id')->constrained('sellers')->onDelete('cascade');
+            $table->foreignId('governorate_id')->constrained('governorates')->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('seller_governorate_coverages');
+    }
+};

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -11,10 +11,11 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-         $this->call([
-             AdminRoleTable::class,
-             AdminTable::class,
-             SellerTableSeeder::class
-         ]);
+        $this->call([
+            AdminRoleTable::class,
+            AdminTable::class,
+            SellerTableSeeder::class,
+            GovernoratesTableSeeder::class
+        ]);
     }
 }

--- a/database/seeds/GovernoratesTableSeeder.php
+++ b/database/seeds/GovernoratesTableSeeder.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class GovernoratesTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run()
+    {
+        $governorates = [
+            'القاهرة',
+            'الجيزة',
+            'الإسكندرية',
+            'الدقهلية',
+            'البحر الأحمر',
+            'البحيرة',
+            'الفيوم',
+            'الغربية',
+            'الإسماعيلية',
+            'المنوفية',
+            'المنيا',
+            'القليوبية',
+            'الوادي الجديد',
+            'السويس',
+            'أسوان',
+            'أسيوط',
+            'بني سويف',
+            'بورسعيد',
+            'دمياط',
+            'الشرقية',
+            'جنوب سيناء',
+            'كفر الشيخ',
+            'مطروح',
+            'الأقصر',
+            'قنا',
+            'شمال سيناء',
+            'سوهاج',
+        ];
+
+        foreach ($governorates as $name) {
+            DB::table('governorates')->insert([
+                'name_ar' => $name,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+    }
+}

--- a/resources/views/admin-views/vendor/add-new-vendor.blade.php
+++ b/resources/views/admin-views/vendor/add-new-vendor.blade.php
@@ -426,6 +426,22 @@
                     </div>
                 </div>
             </div>
+            <div class="card mb-4">
+                <div class="card-header">
+                    <h3 class="fs-18">{{ translate('Coverage_Governorates') }}</h3>
+                    <p class="mb-0 fs-12">{{ translate('select_governorates_this_vendor_covers') }}</p>
+                </div>
+                <div class="card-body">
+                    <div class="form-group mb-0">
+                        <label class="form-label mb-2">{{ translate('Governorates') }}</label>
+                        <select name="governorates[]" class="form-control js-select2-custom" multiple>
+                            @foreach($governorates as $governorate)
+                                <option value="{{ $governorate->id }}">{{ $governorate->name_ar }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                </div>
+            </div>
             <div class="d-flex justify-content-end trans3 mt-4">
                 <div
                     class="d-flex justify-content-sm-end justify-content-center gap-3 flex-grow-1 flex-grow-sm-0 bg-white action-btn-wrapper trans3">

--- a/resources/views/admin-views/vendor/view/setting.blade.php
+++ b/resources/views/admin-views/vendor/view/setting.blade.php
@@ -206,6 +206,27 @@
                     </div>
                 </div>
             </div>
+            <div class="col-md-6">
+                <form action="{{ route('admin.vendors.update-setting',['id'=>$seller['id']]) }}" method="post" id="update-setting-form-coverage">
+                    @csrf
+                    <div class="card">
+                        <div class="card-header d-flex justify-content-between gap-2">
+                            <h4 class="mb-0">{{ translate('coverage_governorates') }}</h4>
+                        </div>
+                        <div class="card-body">
+                            <div class="form-group">
+                                <label class="mb-2">{{ translate('Governorates') }}</label>
+                                <select name="governorates[]" class="form-control js-select2-custom" multiple>
+                                    @foreach($governorates as $governorate)
+                                        <option value="{{ $governorate->id }}" {{ $seller->governorate_coverages->contains($governorate->id) ? 'selected' : '' }}>{{ $governorate->name_ar }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
+                            <button type="submit" class="btn btn-primary">{{ translate('update') }}</button>
+                        </div>
+                    </div>
+                </form>
+            </div>
         </div>
     </div>
 @endsection


### PR DESCRIPTION
## Summary
- add tables and seeders for Egyptian governorates and seller coverage
- allow admins to select coverage governorates when creating or editing vendors
- store selected coverage on vendor creation and update

## Testing
- `composer install` *(fails: Your lock file does not contain a compatible set of packages / GitHub authentication required)*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68a265c89b0483269c6d146d761c5992