### PR TITLE
feat(pos): add governorate-based city and seller selection

### DIFF
--- a/app/Http/Controllers/Admin/Customer/CustomerController.php
+++ b/app/Http/Controllers/Admin/Customer/CustomerController.php
@@ -373,19 +373,22 @@ class CustomerController extends BaseController
         $token = Str::random(120);
         $this->passwordResetRepo->add($this->passwordResetService->getAddData(identity: $request['phone'], token: $token, userType: 'customer'));
         $this->customerRepo->add($customerService->getCustomerData(request: $request));
-        $customer = $this->customerRepo->getFirstWhere(params: ['email' => $request['email']]);
+        $customer = $this->customerRepo->getFirstWhere(params: ['phone' => $request['phone']]);
         $this->shippingAddressRepo->add($this->shippingAddressService->getAddAddressData(request: $request, customerId: $customer['id'], addressType: 'home'));
-        $resetRoute = route('customer.auth.recover-password');
-        $data = [
-            'userName' => $request['f_name'],
-            'userType' => 'customer',
-            'templateName' => 'registration-from-pos',
-            'subject' => translate('Customer_Registration_Successfully_Completed'),
-            'title' => translate('welcome_to') . ' ' . getWebConfig('company_name') . '!',
-            'resetPassword' => $resetRoute,
-            'message' => translate('thank_you_for_joining') . ' ' . getWebConfig('company_name') . '.' . translate('if_you_want_to_become_a_registered_customer_then_reset_your_password_below_by_using_this_phone') . ' ' . ($request['phone']) . '.' . translate('then_you’ll_be_able_to_explore_the_website_and_app_as_a_registered_customer') . '.',
-        ];
-        event(new CustomerRegistrationEvent(email: $request['email'], data: $data));
+        session(['selected_city_id' => $request['city_id'], 'selected_seller_id' => $request['seller_id']]);
+        if ($request['email']) {
+            $resetRoute = route('customer.auth.recover-password');
+            $data = [
+                'userName' => $request['f_name'],
+                'userType' => 'customer',
+                'templateName' => 'registration-from-pos',
+                'subject' => translate('Customer_Registration_Successfully_Completed'),
+                'title' => translate('welcome_to') . ' ' . getWebConfig('company_name') . '!',
+                'resetPassword' => $resetRoute,
+                'message' => translate('thank_you_for_joining') . ' ' . getWebConfig('company_name') . '.' . translate('if_you_want_to_become_a_registered_customer_then_reset_your_password_below_by_using_this_phone') . ' ' . ($request['phone']) . '.' . translate('then_you’ll_be_able_to_explore_the_website_and_app_as_a_registered_customer') . '.',
+            ];
+            event(new CustomerRegistrationEvent(email: $request['email'], data: $data));
+        }
         ToastMagic::success(translate('customer_added_successfully'));
         return redirect()->back();
     }

--- a/app/Http/Controllers/Admin/POS/POSOrderController.php
+++ b/app/Http/Controllers/Admin/POS/POSOrderController.php
@@ -89,6 +89,8 @@ class POSOrderController extends BaseController
     {
         $amount = $request['amount'];
         $paidAmount = $request['type'] == 'cash' ? ($request['paid_amount'] ?? 0) : null;
+        $sellerId = $request['seller_id'];
+        $cityId = $request['city_id'];
         $cartId = session(SessionKey::CURRENT_USER);
         $condition = $this->POSService->checkConditions(amount: $amount, paidAmount: $paidAmount);
         if ($condition == 'true') {
@@ -166,7 +168,9 @@ class POSOrderController extends BaseController
             paidAmount: $request['type'] == 'cash' ? $paidAmount : $amount,
             paymentType: $request['type'],
             addedBy: 'admin',
-            userId: $userId
+            userId: $userId,
+            sellerId: $sellerId,
+            cityId: $cityId,
         );
         $this->orderRepo->add(data: $order);
         if ($checkProductTypeDigital) {

--- a/app/Http/Controllers/Vendor/POS/POSOrderController.php
+++ b/app/Http/Controllers/Vendor/POS/POSOrderController.php
@@ -184,7 +184,9 @@ class POSOrderController extends BaseController
             paidAmount: $request['type'] == 'cash' ? $paidAmount : $amount,
             paymentType: $request['type'],
             addedBy: 'seller',
-            userId: $userId
+            userId: $userId,
+            sellerId: auth('seller')->id(),
+            cityId: $request['city_id'] ?? null,
         );
         $this->orderRepo->add(data: $order);
         if ($checkProductTypeDigital) {

--- a/app/Http/Requests/Admin/CustomerRequest.php
+++ b/app/Http/Requests/Admin/CustomerRequest.php
@@ -24,22 +24,20 @@ class CustomerRequest extends FormRequest
     {
         return [
             'f_name' => 'required',
-            'l_name' => 'required',
-            'email' => 'required|email|unique:users',
-            'phone' => 'unique:users|min:4|max:20',
+            'phone' => 'required|unique:users|min:4|max:20',
+            'city_id' => 'required|exists:governorates,id',
+            'seller_id' => 'required|exists:sellers,id',
         ];
     }
     public function messages(): array
     {
         return [
             'name.required' => translate('first_name_is_required'),
-            'l_name.required' => translate('last_name_is_required'),
-            'email.required' => translate('email_is_required'),
-            'email.email' => translate('email_must_be_valid'),
-            'email.unique' => translate('email_already_in_use'),
             'phone.required' => translate('phone_is_required'),
             'phone.max' => translate('please_ensure_your_phone_number_is_valid_and_does_not_exceed_20_characters'),
             'phone.min' => translate('phone_number_with_a_minimum_length_requirement_of_4_characters'),
+            'city_id.required' => translate('city_is_required'),
+            'seller_id.required' => translate('seller_is_required'),
         ];
     }
 }

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -112,6 +112,7 @@ class Order extends Model
         'delivery_type',
         'delivery_service_name',
         'third_party_delivery_tracking_id',
+        'city_id',
     ];
 
     protected $casts = [
@@ -163,6 +164,7 @@ class Order extends Model
         'delivery_type' => 'string',
         'delivery_service_name' => 'string',
         'third_party_delivery_tracking_id' => 'string',
+        'city_id' => 'integer',
     ];
 
 

--- a/app/Services/CustomerService.php
+++ b/app/Services/CustomerService.php
@@ -13,15 +13,16 @@ class CustomerService
      */
     public function getCustomerData(object $request):array
     {
+        $cityName = $request['city_id'] ? (\App\Models\Governorate::find($request['city_id'])->name_ar ?? null) : ($request['city'] ?? null);
         return [
             'f_name' => $request['f_name'],
-            'l_name' => $request['l_name'],
-            'email' => $request['email'],
+            'l_name' => $request['l_name'] ?? null,
+            'email' => $request['email'] ?? null,
             'phone' => $request['phone'],
-            'country' => $request['country']??null,
-            'city' => $request['city']??null,
-            'zip' => $request['zip_code']??null,
-            'street_address' =>$request['address']??null,
+            'country' => $request['country'] ?? null,
+            'city' => $cityName,
+            'zip' => $request['zip_code'] ?? null,
+            'street_address' => $request['address'] ?? null,
             'password' => bcrypt($request['password'] ?? 'password')
         ];
     }

--- a/app/Services/OrderService.php
+++ b/app/Services/OrderService.php
@@ -8,7 +8,7 @@ class OrderService
     {
     }
 
-    public function getPOSOrderData(int|string $orderId, array $cart, float $amount, float $paidAmount, string $paymentType, string $addedBy, int $userId): array
+    public function getPOSOrderData(int|string $orderId, array $cart, float $amount, float $paidAmount, string $paymentType, string $addedBy, int $userId, ?int $sellerId = null, ?int $cityId = null): array
     {
         return [
             'id' => $orderId,
@@ -16,7 +16,7 @@ class OrderService
             'customer_type' => 'customer',
             'payment_status' => 'paid',
             'order_status' => 'delivered',
-            'seller_id' => $addedBy == 'seller' ? auth('seller')->id() : auth('admin')->id(),
+            'seller_id' => $sellerId ?? ($addedBy == 'seller' ? auth('seller')->id() : auth('admin')->id()),
             'seller_is' => $addedBy,
             'payment_method' => $paymentType,
             'order_type' => 'POS',
@@ -29,6 +29,7 @@ class OrderService
             'coupon_code' => $cart['coupon_code'] ?? null,
             'discount_type' => (isset($cart['coupon_code']) && $cart['coupon_code']) ? 'coupon_discount' : NULL,
             'coupon_discount_bearer' => $cart['coupon_bearer'] ?? 'inhouse',
+            'city_id' => $cityId,
             'created_at' => now(),
             'updated_at' => now(),
         ];

--- a/app/Services/ShippingAddressService.php
+++ b/app/Services/ShippingAddressService.php
@@ -6,14 +6,19 @@ class ShippingAddressService
 {
     public function getAddAddressData($request,$customerId,$addressType):array
     {
+        $city = $request['city_id'] ? (\App\Models\Governorate::find($request['city_id'])->name_ar ?? null) : ($request['city'] ?? null);
+        $name = $request['f_name'];
+        if (!empty($request['l_name'])) {
+            $name .= ' '.$request['l_name'];
+        }
         return [
             'customer_id' => $customerId,
-            'contact_person_name' => $request['f_name'].' '.$request['f_name'],
+            'contact_person_name' => $name,
             'address_type' => $addressType,
             'address' => $request['address'],
-            'city' => $request['city'],
-            'zip' => $request['zip_code'],
-            'country' => $request['country'],
+            'city' => $city,
+            'zip' => $request['zip_code'] ?? null,
+            'country' => $request['country'] ?? null,
             'phone' => $request['phone'],
             'is_billing' => 0,
             'latitude' => 0,

--- a/database/migrations/2025_08_01_000200_add_city_id_to_orders_table.php
+++ b/database/migrations/2025_08_01_000200_add_city_id_to_orders_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->foreignId('city_id')->nullable()->constrained('governorates')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('city_id');
+        });
+    }
+};

--- a/public/assets/back-end/js/admin/pos-script.js
+++ b/public/assets/back-end/js/admin/pos-script.js
@@ -1224,3 +1224,17 @@ $(".close-alert--message-for-pos").on("click", function () {
     $(".alert--message-for-pos").removeClass("active");
 });
 
+$("#city_id").on("change", function () {
+    $.get({
+        url: $("#route-admin-pos-get-sellers").data("url"),
+        data: {governorate_id: $(this).val()},
+        success: function (data) {
+            let seller = $("#seller_id");
+            seller.empty();
+            $.each(data, function (key, value) {
+                seller.append('<option value="' + value.id + '">' + value.name + '</option>');
+            });
+        }
+    });
+});
+

--- a/resources/views/admin-views/pos/index.blade.php
+++ b/resources/views/admin-views/pos/index.blade.php
@@ -162,6 +162,7 @@
 <span id="route-admin-pos-update-quantity" data-url="{{ route('admin.pos.update-quantity') }}"></span>
 <span id="route-admin-pos-get-variant-price" data-url="{{ route('admin.pos.get-variant-price') }}"></span>
 <span id="route-admin-pos-change-cart-editable" data-url="{{ route('admin.pos.change-cart').'/?cart_id=:value' }}"></span>
+<span id="route-admin-pos-get-sellers" data-url="{{ route('admin.pos.get-sellers') }}"></span>
 
 <span id="message-cart-word" data-text="{{ translate('cart') }}"></span>
 <span id="message-stock-out" data-text="{{ translate('stock_out') }}"></span>

--- a/resources/views/admin-views/pos/partials/_cart.blade.php
+++ b/resources/views/admin-views/pos/partials/_cart.blade.php
@@ -1,5 +1,7 @@
 <form action="{{route('admin.pos.place-order') }}" method="post" id='order-place'>
     @csrf
+    <input type="hidden" name="city_id" value="{{ session('selected_city_id') }}">
+    <input type="hidden" name="seller_id" value="{{ session('selected_seller_id') }}">
     <div id="cart">
         <div class="table-responsive pos-cart-table border">
             <table class="table table-align-middle m-0">

--- a/resources/views/admin-views/pos/partials/modals/_add-customer.blade.php
+++ b/resources/views/admin-views/pos/partials/modals/_add-customer.blade.php
@@ -21,22 +21,6 @@
                         </div>
                         <div class="col-12 col-lg-6">
                             <div class="form-group">
-                                <label class="form-label mb-1">{{ translate('last_name') }}
-                                    <span class="input-label-secondary text-danger">*</span></label>
-                                <input type="text" name="l_name" class="form-control" value="{{ old('l_name') }}"
-                                       placeholder="{{ translate('last_name') }}" required>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6">
-                            <div class="form-group">
-                                <label class="form-label mb-1">{{ translate('email') }} <span
-                                        class="input-label-secondary text-danger">*</span></label>
-                                <input type="email" name="email" class="form-control" value="{{ old('email') }}"
-                                       placeholder="{{ translate('ex').': ex@example.com' }}" required>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6">
-                            <div class="form-group">
                                 <label class="form-label mb-1">{{ translate('phone') }} <span
                                         class="input-label-secondary text-danger">*</span></label>
                                 <input class="form-control"
@@ -46,38 +30,22 @@
                         </div>
                         <div class="col-12 col-lg-6">
                             <div class="form-group">
-                                <label class="form-label mb-1">{{ translate('country') }}</label>
-                                <select name="country" class="custom-select" data-live-search="true">
-                                    @foreach($countries as $country)
-                                        <option value="{{ $country['name'] }}">{{ $country['name'] }}</option>
+                                <label class="form-label mb-1">{{ translate('city') }} <span class="input-label-secondary text-danger">*</span></label>
+                                <select name="city_id" id="city_id" class="custom-select" data-live-search="true" required>
+                                    <option value="">{{ translate('select') }}</option>
+                                    @foreach($governorates as $governorate)
+                                        <option value="{{ $governorate->id }}">{{ $governorate->name_ar }}</option>
                                     @endforeach
                                 </select>
                             </div>
                         </div>
                         <div class="col-12 col-lg-6">
                             <div class="form-group">
-                                <label class="form-label mb-1">{{ translate('city') }}</label>
-                                <input type="text" name="city" class="form-control" value="{{ old('city') }}"
-                                       placeholder="{{ translate('city') }}">
+                                <label class="form-label mb-1">{{ translate('seller') }} <span class="input-label-secondary text-danger">*</span></label>
+                                <select name="seller_id" id="seller_id" class="custom-select" required></select>
                             </div>
                         </div>
-                        <div class="col-12 col-lg-6">
-                            <div class="form-group">
-                                <label class="form-label mb-1">{{ translate('zip_code') }}</label>
-                                @if($zipCodes)
-                                    <select name="zip" class="form-control js-select2-custom" data-live-search="true">
-                                        @foreach($zipCodes as $code)
-                                            <option
-                                                value="{{ $code->zipcode }}">{{ $code->zipcode }}</option>
-                                        @endforeach
-                                    </select>
-                                @else
-                                    <input type="text" name="zip_code" class="form-control"
-                                           value="{{ old('zip_code') }}" placeholder="{{ translate('zip_code') }}">
-                                @endif
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-6">
+                        <div class="col-12">
                             <div class="form-group">
                                 <label class="form-label mb-1">{{ translate('address') }}</label>
                                 <input type="text" name="address" class="form-control" value="{{ old('address') }}"

--- a/routes/admin/routes.php
+++ b/routes/admin/routes.php
@@ -154,6 +154,7 @@ Route::group(['prefix' => 'admin', 'as' => 'admin.', 'middleware' => ['admin', '
             Route::post('coupon-discount', 'getCouponDiscount')->name('coupon-discount');
             Route::get('quick-view', 'getQuickView')->name('quick-view');
             Route::get('search-product', 'getSearchedProductsView')->name('search-product');
+            Route::get('get-sellers', 'getSellers')->name('get-sellers');
         });
 
         Route::controller(CartController::class)->group(function () {


### PR DESCRIPTION
## Summary
- remove unused last name, email, country, and zip fields from POS add customer modal
- load governorates and sellers dynamically and persist selected seller and city for orders
- store city reference on orders via new city_id column

## Testing
- `composer install --no-interaction` (fails: kreait/firebase-php 7.10.0 requires php ~8.1.0 || ~8.2.0 || ~8.3.0)


------
https://chatgpt.com/codex/tasks/task_e_68a26eba7cf88326b5829dcfcf564681