### PR TITLE
Enable inline customer and address creation in POS

### DIFF
--- a/app/Http/Controllers/Admin/Customer/CustomerController.php
+++ b/app/Http/Controllers/Admin/Customer/CustomerController.php
@@ -368,14 +368,19 @@ class CustomerController extends BaseController
         return response()->json($customers);
     }
 
-    public function add(CustomerRequest $request, CustomerService $customerService): RedirectResponse
+    public function add(CustomerRequest $request, CustomerService $customerService): RedirectResponse|JsonResponse
     {
-        $token = Str::random(120);
-        $this->passwordResetRepo->add($this->passwordResetService->getAddData(identity: $request['phone'], token: $token, userType: 'customer'));
-        $this->customerRepo->add($customerService->getCustomerData(request: $request));
         $customer = $this->customerRepo->getFirstWhere(params: ['phone' => $request['phone']]);
+        if (!$customer) {
+            $token = Str::random(120);
+            $this->passwordResetRepo->add($this->passwordResetService->getAddData(identity: $request['phone'], token: $token, userType: 'customer'));
+            $this->customerRepo->add($customerService->getCustomerData(request: $request));
+            $customer = $this->customerRepo->getFirstWhere(params: ['phone' => $request['phone']]);
+        }
+
         $this->shippingAddressRepo->add($this->shippingAddressService->getAddAddressData(request: $request, customerId: $customer['id'], addressType: 'home'));
         session(['selected_city_id' => $request['city_id'], 'selected_seller_id' => $request['seller_id']]);
+
         if ($request['email']) {
             $resetRoute = route('customer.auth.recover-password');
             $data = [
@@ -389,7 +394,35 @@ class CustomerController extends BaseController
             ];
             event(new CustomerRegistrationEvent(email: $request['email'], data: $data));
         }
+
+        if ($request->ajax()) {
+            return response()->json([
+                'customer' => $customer,
+                'message' => translate('customer_added_successfully'),
+            ]);
+        }
+
         ToastMagic::success(translate('customer_added_successfully'));
         return redirect()->back();
+    }
+
+    public function addAddress(Request $request): JsonResponse
+    {
+        $request->validate([
+            'customer_id' => 'required|integer',
+            'city_id' => 'required|integer',
+            'seller_id' => 'required|integer',
+            'address' => 'required|string',
+        ]);
+
+        $customer = $this->customerRepo->getFirstWhere(params: ['id' => $request['customer_id']]);
+        if (!$customer) {
+            return response()->json(['message' => translate('The_selected_customer_does_not_exist')], 404);
+        }
+
+        $this->shippingAddressRepo->add($this->shippingAddressService->getAddAddressData(request: $request, customerId: $customer['id'], addressType: 'home'));
+        session(['selected_city_id' => $request['city_id'], 'selected_seller_id' => $request['seller_id']]);
+
+        return response()->json(['message' => translate('address_added_successfully!')]);
     }
 }

--- a/public/assets/back-end/js/admin/pos-script.js
+++ b/public/assets/back-end/js/admin/pos-script.js
@@ -1224,17 +1224,81 @@ $(".close-alert--message-for-pos").on("click", function () {
     $(".alert--message-for-pos").removeClass("active");
 });
 
-$("#city_id").on("change", function () {
+$(document).on("change", "#customer_city_id, #address_city_id", function () {
+    let target = $(this).attr("id") === "customer_city_id" ? "#customer_seller_id" : "#address_seller_id";
     $.get({
         url: $("#route-admin-pos-get-sellers").data("url"),
         data: {governorate_id: $(this).val()},
         success: function (data) {
-            let seller = $("#seller_id");
+            let seller = $(target);
             seller.empty();
             $.each(data, function (key, value) {
                 seller.append('<option value="' + value.id + '">' + value.name + '</option>');
             });
-        }
+        },
+    });
+});
+
+$("#add_new_customer").on("click", function () {
+    $("#add-customer-card").toggleClass("d-none");
+    $("#add-address-card").addClass("d-none");
+});
+
+$("#add_new_address").on("click", function () {
+    $("#address_customer_id").val($("#customer").val());
+    $("#add-address-card").toggleClass("d-none");
+    $("#add-customer-card").addClass("d-none");
+});
+
+$("#customer").on("change", function () {
+    if ($(this).val() == 0) {
+        $("#add_new_address").addClass("d-none");
+    } else {
+        $("#add_new_address").removeClass("d-none");
+    }
+});
+
+$("#customer_form").on("submit", function (e) {
+    e.preventDefault();
+    $.post({
+        url: $("#route-admin-customer-add").data("url"),
+        data: $(this).serialize(),
+        beforeSend: function () {
+            $("#loading").fadeIn();
+        },
+        success: function (data) {
+            toastr.success(data.message);
+            let optionExists = $("#customer option[value=" + data.customer.id + "]").length;
+            let customerText = data.customer.f_name + " " + (data.customer.l_name ?? "") + " (" + data.customer.phone + ")";
+            if (!optionExists) {
+                $("#customer").append('<option value="' + data.customer.id + '">' + customerText + "</option>");
+            }
+            $("#customer").val(data.customer.id).trigger("change");
+            $("#customer_form")[0].reset();
+            $("#add-customer-card").addClass("d-none");
+        },
+        complete: function () {
+            $("#loading").fadeOut();
+        },
+    });
+});
+
+$("#customer_address_form").on("submit", function (e) {
+    e.preventDefault();
+    $.post({
+        url: $("#route-admin-customer-address-add").data("url"),
+        data: $(this).serialize(),
+        beforeSend: function () {
+            $("#loading").fadeIn();
+        },
+        success: function (data) {
+            toastr.success(data.message);
+            $("#customer_address_form")[0].reset();
+            $("#add-address-card").addClass("d-none");
+        },
+        complete: function () {
+            $("#loading").fadeOut();
+        },
     });
 });
 

--- a/resources/views/admin-views/pos/index.blade.php
+++ b/resources/views/admin-views/pos/index.blade.php
@@ -110,10 +110,94 @@
                                 @endforeach
                             </select>
 
-                            <button class="btn btn-success rounded text-nowrap" id="add_new_customer" type="button"
-                                    data-bs-toggle="modal" data-bs-target="#add-customer" title="{{ translate('add_new_customer') }}">
+                            <button class="btn btn-success rounded text-nowrap" id="add_new_customer" type="button" title="{{ translate('add_new_customer') }}">
                                 {{ translate('add_New_Customer') }}
                             </button>
+
+                            <button class="btn btn-primary rounded text-nowrap d-none" id="add_new_address" type="button" title="{{ translate('add_new_address') }}">
+                                {{ translate('add_new_address') }}
+                            </button>
+                        </div>
+
+                        <div id="add-customer-card" class="border rounded p-3 mt-3 d-none">
+                            <form id="customer_form">
+                                @csrf
+                                <div class="row g-3">
+                                    <div class="col-12 col-lg-6">
+                                        <div class="form-group">
+                                            <label class="form-label mb-1">{{ translate('first_name') }} <span class="input-label-secondary text-danger">*</span></label>
+                                            <input type="text" name="f_name" class="form-control" placeholder="{{ translate('first_name') }}" required>
+                                        </div>
+                                    </div>
+                                    <div class="col-12 col-lg-6">
+                                        <div class="form-group">
+                                            <label class="form-label mb-1">{{ translate('phone') }} <span class="input-label-secondary text-danger">*</span></label>
+                                            <input class="form-control" type="tel" name="phone" placeholder="{{ translate('enter_phone_number') }}" required>
+                                        </div>
+                                    </div>
+                                    <div class="col-12 col-lg-6">
+                                        <div class="form-group">
+                                            <label class="form-label mb-1">{{ translate('city') }} <span class="input-label-secondary text-danger">*</span></label>
+                                            <select name="city_id" id="customer_city_id" class="custom-select" required>
+                                                <option value="">{{ translate('select') }}</option>
+                                                @foreach($governorates as $governorate)
+                                                    <option value="{{ $governorate->id }}">{{ $governorate->name_ar }}</option>
+                                                @endforeach
+                                            </select>
+                                        </div>
+                                    </div>
+                                    <div class="col-12 col-lg-6">
+                                        <div class="form-group">
+                                            <label class="form-label mb-1">{{ translate('seller') }} <span class="input-label-secondary text-danger">*</span></label>
+                                            <select name="seller_id" id="customer_seller_id" class="custom-select" required></select>
+                                        </div>
+                                    </div>
+                                    <div class="col-12">
+                                        <div class="form-group">
+                                            <label class="form-label mb-1">{{ translate('address') }}</label>
+                                            <input type="text" name="address" class="form-control" placeholder="{{ translate('address') }}">
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="d-flex justify-content-end mt-2">
+                                    <button type="submit" id="submit_new_customer" class="btn btn-primary">{{ translate('submit') }}</button>
+                                </div>
+                            </form>
+                        </div>
+
+                        <div id="add-address-card" class="border rounded p-3 mt-3 d-none">
+                            <form id="customer_address_form">
+                                @csrf
+                                <input type="hidden" name="customer_id" id="address_customer_id">
+                                <div class="row g-3">
+                                    <div class="col-12 col-lg-6">
+                                        <div class="form-group">
+                                            <label class="form-label mb-1">{{ translate('city') }} <span class="input-label-secondary text-danger">*</span></label>
+                                            <select name="city_id" id="address_city_id" class="custom-select" required>
+                                                <option value="">{{ translate('select') }}</option>
+                                                @foreach($governorates as $governorate)
+                                                    <option value="{{ $governorate->id }}">{{ $governorate->name_ar }}</option>
+                                                @endforeach
+                                            </select>
+                                        </div>
+                                    </div>
+                                    <div class="col-12 col-lg-6">
+                                        <div class="form-group">
+                                            <label class="form-label mb-1">{{ translate('seller') }} <span class="input-label-secondary text-danger">*</span></label>
+                                            <select name="seller_id" id="address_seller_id" class="custom-select" required></select>
+                                        </div>
+                                    </div>
+                                    <div class="col-12">
+                                        <div class="form-group">
+                                            <label class="form-label mb-1">{{ translate('address') }}</label>
+                                            <input type="text" name="address" class="form-control" placeholder="{{ translate('address') }}" required>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="d-flex justify-content-end mt-2">
+                                    <button type="submit" class="btn btn-primary">{{ translate('submit') }}</button>
+                                </div>
+                            </form>
                         </div>
 
                         <div id="cart-summary">
@@ -140,7 +224,6 @@
 @include('admin-views.pos.partials.modals._print-invoice')
 @endif
 
-@include('admin-views.pos.partials.modals._add-customer')
 @include('admin-views.pos.partials.modals._hold-orders-modal')
 @include('admin-views.pos.partials.modals._add-coupon-discount')
 @include('admin-views.pos.partials.modals._add-discount')
@@ -163,6 +246,8 @@
 <span id="route-admin-pos-get-variant-price" data-url="{{ route('admin.pos.get-variant-price') }}"></span>
 <span id="route-admin-pos-change-cart-editable" data-url="{{ route('admin.pos.change-cart').'/?cart_id=:value' }}"></span>
 <span id="route-admin-pos-get-sellers" data-url="{{ route('admin.pos.get-sellers') }}"></span>
+<span id="route-admin-customer-add" data-url="{{ route('admin.customer.add') }}"></span>
+<span id="route-admin-customer-address-add" data-url="{{ route('admin.customer.address-add') }}"></span>
 
 <span id="message-cart-word" data-text="{{ translate('cart') }}"></span>
 <span id="message-stock-out" data-text="{{ translate('stock_out') }}"></span>

--- a/routes/admin/routes.php
+++ b/routes/admin/routes.php
@@ -335,6 +335,7 @@ Route::group(['prefix' => 'admin', 'as' => 'admin.', 'middleware' => ['admin', '
             Route::get('customer-list-search', 'getCustomerList')->name('customer-list-search');
             Route::get('customer-list-without-all-customer', 'getCustomerListWithoutAllCustomerName')->name('customer-list-without-all-customer');
             Route::post('add', 'add')->name('add');
+            Route::post('address-add', 'addAddress')->name('address-add');
         });
 
         Route::group(['prefix' => 'wallet', 'as' => 'wallet.'], function () {


### PR DESCRIPTION
## Summary
- Allow creating customers directly on POS billing section without page refresh
- Support adding additional addresses for existing POS customers
- Expose routes and JS handlers for AJAX customer and address creation

## Testing
- `php -l app/Http/Controllers/Admin/Customer/CustomerController.php`
- `php -l routes/admin/routes.php`
- `php artisan test --filter=none` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68a274c005d083268a88d26ece8b518c