### PR TITLE
Refactor POS cart rendering

### DIFF
--- a/public/assets/back-end/js/admin/pos-script.js
+++ b/public/assets/back-end/js/admin/pos-script.js
@@ -4,6 +4,7 @@ let elementViewAllHoldOrdersSearch = $(".view_all_hold_orders_search");
 let getYesWord = $("#message-yes-word").data("text");
 let getNoWord = $("#message-no-word").data("text");
 let messageAreYouSure = $("#message-are-you-sure").data("text");
+let localPosCart = window.localPosCart || {};
 
 document.addEventListener("keydown", function (event) {
     if (event.altKey && event.code === "KeyO") {
@@ -125,6 +126,33 @@ function disableOrderPlaceButton() {
         $(".action-form-submit").attr("disabled", true);
     } else {
         $(".action-form-submit").attr("disabled", false);
+    }
+}
+
+function renderLocalCart(data) {
+    if (data?.cart) {
+        localPosCart = data.cart;
+    }
+    if (data?.view) {
+        $("#cart-items").empty().html(data.view);
+    }
+    if (typeof localPosCart === "object") {
+        const subTotal = parseFloat(localPosCart.subtotal || 0) +
+            parseFloat(localPosCart.discountOnProduct || 0);
+        const productDiscount = parseFloat(localPosCart.discountOnProduct || 0);
+        const extraDiscount = parseFloat(localPosCart.extraDiscount || 0);
+        const couponDiscount = parseFloat(localPosCart.couponDiscount || 0);
+        const tax = parseFloat(localPosCart.totalTax || 0);
+        const total = parseFloat(localPosCart.total || 0) + tax - couponDiscount;
+        $("#cart-subtotal").text(subTotal.toFixed(2));
+        $("#cart-product-discount").text(productDiscount.toFixed(2));
+        $("#cart-extra-discount").text(extraDiscount.toFixed(2));
+        $("#cart-coupon-discount").text(couponDiscount.toFixed(2));
+        $("#cart-tax").text(tax.toFixed(2));
+        $("#cart-total").text(total.toFixed(2));
+        $(".total-amount").val(total.toFixed(2));
+        $(".pos-paid-amount-element").val(total.toFixed(2));
+        $(".pos-paid-amount-element").attr("min", total.toFixed(2));
     }
 }
 $(".action-customer-change").on("change", function () {
@@ -497,7 +525,7 @@ $(".action-coupon-discount").on("click", function (event) {
                     toastMagic.warning($("#message-coupon-is-invalid").data("text"));
                 }
                 $("#add-coupon-discount").modal("hide");
-                $("#cart").empty().html(data.view);
+                renderLocalCart(data);
                 reinitializeTooltips();
                 basicFunctionalityForCartSummary();
                 posUpdateQuantityFunctionality();
@@ -568,7 +596,7 @@ $(".action-extra-discount").on("click", function (event) {
                 }
                 $("#add-discount").modal("hide");
                 $(".modal-backdrop").addClass("d-none");
-                $("#cart").empty().html(data.view);
+                renderLocalCart(data);
                 reinitializeTooltips();
                 basicFunctionalityForCartSummary();
                 posUpdateQuantityFunctionality();
@@ -664,7 +692,7 @@ function updateQuantityResponseProcess(data) {
             }
         );
     }
-    $("#cart").empty().html(data.view);
+    renderLocalCart(data);
     reinitializeTooltips();
     posUpdateQuantityFunctionality();
     viewAllHoldOrders("keyup");
@@ -1091,7 +1119,7 @@ function addToCart(form_id = "add-to-cart-form") {
                         ProgressBar: true,
                     }
                 );
-                $("#cart").empty().html(data.view);
+                renderLocalCart(data);
                 reinitializeTooltips();
                 viewAllHoldOrders("keyup");
                 $(".search-result-box").empty().hide();
@@ -1124,7 +1152,7 @@ function removeFromCart() {
                 variant: variant,
             },
             function (data) {
-                $("#cart").empty().html(data.view);
+                renderLocalCart(data);
                 reinitializeTooltips();
                 if (data.errors) {
                     for (let index = 0; index < data.errors.length; index++) {

--- a/resources/views/admin-views/pos/partials/_cart.blade.php
+++ b/resources/views/admin-views/pos/partials/_cart.blade.php
@@ -13,7 +13,7 @@
                         <th class="border-0 text-center">{{ translate('delete') }}</th>
                     </tr>
                 </thead>
-                <tbody>
+                <tbody id="cart-items">
                 @foreach($cartItems['cartItemValue'] as $key => $item)
                         @if(is_array($item))
                             <tr>
@@ -62,12 +62,12 @@
             <dl>
                 <div class="d-flex gap-2 justify-content-between">
                     <dt class="title-color text-capitalize font-weight-normal">{{ translate('sub_total') }} : </dt>
-                    <dd>{{setCurrencySymbol(amount: usdToDefaultCurrency(amount: $cartItems['subtotal'] + $cartItems['discountOnProduct']), currencyCode: getCurrencyCode())}}</dd>
+                    <dd id="cart-subtotal">{{setCurrencySymbol(amount: usdToDefaultCurrency(amount: $cartItems['subtotal'] + $cartItems['discountOnProduct']), currencyCode: getCurrencyCode())}}</dd>
                 </div>
 
                 <div class="d-flex gap-2 justify-content-between">
                     <dt class="title-color text-capitalize font-weight-normal">{{ translate('product_Discount') }} :</dt>
-                    <dd>{{setCurrencySymbol(amount: usdToDefaultCurrency(amount:round($cartItems['discountOnProduct'], 2)), currencyCode: getCurrencyCode()) }}</dd>
+                    <dd id="cart-product-discount">{{setCurrencySymbol(amount: usdToDefaultCurrency(amount:round($cartItems['discountOnProduct'], 2)), currencyCode: getCurrencyCode()) }}</dd>
                 </div>
 
                 <div class="d-flex gap-2 justify-content-between">
@@ -76,7 +76,7 @@
                         <button id="extra_discount" class="btn btn-sm p-0" type="button" data-bs-toggle="modal" data-bs-target="#add-discount">
                             <i class="fi fi-rr-pencil"></i>
                         </button>
-                        {{ setCurrencySymbol(amount: usdToDefaultCurrency(amount: $cartItems['extraDiscount']), currencyCode: getCurrencyCode()) }}
+                        <span id="cart-extra-discount">{{ setCurrencySymbol(amount: usdToDefaultCurrency(amount: $cartItems['extraDiscount']), currencyCode: getCurrencyCode()) }}</span>
                     </dd>
                 </div>
 
@@ -86,18 +86,18 @@
                         <button id="coupon_discount" class="btn btn-sm p-0" type="button" data-bs-toggle="modal" data-bs-target="#add-coupon-discount">
                             <i class="fi fi-rr-pencil"></i>
                         </button>
-                        {{setCurrencySymbol(amount: usdToDefaultCurrency(amount:$cartItems['couponDiscount']), currencyCode: getCurrencyCode())}}
+                        <span id="cart-coupon-discount">{{setCurrencySymbol(amount: usdToDefaultCurrency(amount:$cartItems['couponDiscount']), currencyCode: getCurrencyCode())}}</span>
                     </dd>
                 </div>
 
                 <div class="d-flex gap-2 justify-content-between">
                     <dt class="title-color text-capitalize font-weight-normal">{{ translate('tax') }} : </dt>
-                    <dd>{{setCurrencySymbol(amount: usdToDefaultCurrency(amount: round($cartItems['totalTax'],2) ), currencyCode: getCurrencyCode())}}</dd>
+                    <dd id="cart-tax">{{setCurrencySymbol(amount: usdToDefaultCurrency(amount: round($cartItems['totalTax'],2) ), currencyCode: getCurrencyCode())}}</dd>
                 </div>
 
                 <div class="d-flex gap-2 border-top justify-content-between pt-2">
                     <dt class="title-color text-capitalize font-weight-bold title-color">{{ translate('total') }} : </dt>
-                    <dd class="font-weight-bold title-color">{{setCurrencySymbol(amount: usdToDefaultCurrency(amount: ($cartItems['total'] + $cartItems['totalTax'] - $cartItems['couponDiscount'])), currencyCode: getCurrencyCode())}}</dd>
+                    <dd id="cart-total" class="font-weight-bold title-color">{{setCurrencySymbol(amount: usdToDefaultCurrency(amount: ($cartItems['total'] + $cartItems['totalTax'] - $cartItems['couponDiscount'])), currencyCode: getCurrencyCode())}}</dd>
                 </div>
             </dl>
 


### PR DESCRIPTION
## Summary
- Wrap cart table body with `#cart-items` and add summary element IDs
- Introduce `renderLocalCart` to update cart items and totals without replacing payment/order sections
- Replace direct `#cart` updates with `renderLocalCart` across cart interactions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68a34dba2e708326bdb60f5c40f65aa2