### PR TITLE
Refactor POS & cart services to use cart data directly

### DIFF
--- a/app/Http/Controllers/Admin/POS/CartController.php
+++ b/app/Http/Controllers/Admin/POS/CartController.php
@@ -42,7 +42,7 @@ class CartController extends BaseController
     {
     }
 
-    public function index(?Request $request, string $type = null): View|Collection|LengthAwarePaginator|null|callable|RedirectResponse
+    public function index(?Request $request, ?string $type = null): View|Collection|LengthAwarePaginator|null|callable|RedirectResponse
     {
         // TODO: Implement index() method.
     }
@@ -173,7 +173,15 @@ class CartController extends BaseController
                     $cartData[] = $cartItem;
                     session([$cartId => $cartData]);
                     $getCurrentCustomerData = $this->getCustomerDataFromSessionForPOS();
-                    $summaryData = array_merge($this->POSService->getSummaryData(), $getCurrentCustomerData);
+                    $cartNames = session(SessionKey::CART_NAME) ?? [];
+                    $allCarts = [];
+                    foreach ($cartNames as $name) {
+                        $allCarts[$name] = session($name);
+                    }
+                    $summaryData = array_merge(
+                        $this->POSService->getSummaryData(carts: $allCarts, currentUser: session(SessionKey::CURRENT_USER)),
+                        $getCurrentCustomerData
+                    );
                     $cartItems = $this->getCartData(cartName: $cartId);
                     return response()->json([
                         'data' => 1,
@@ -269,7 +277,15 @@ class CartController extends BaseController
     {
         $this->cartService->getCartKeeper();
         $getCurrentCustomerData = $this->getCustomerDataFromSessionForPOS();
-        $summaryData = array_merge($this->POSService->getSummaryData(), $getCurrentCustomerData);
+        $cartNames = session(SessionKey::CART_NAME) ?? [];
+        $allCarts = [];
+        foreach ($cartNames as $name) {
+            $allCarts[$name] = session($name);
+        }
+        $summaryData = array_merge(
+            $this->POSService->getSummaryData(carts: $allCarts, currentUser: session(SessionKey::CURRENT_USER)),
+            $getCurrentCustomerData
+        );
         $cartItems = $this->getCartData(cartName: session(SessionKey::CURRENT_USER));
         return response()->json([
             'view' => view('admin-views.pos.partials._cart-summary', compact('summaryData', 'cartItems'))->render(),
@@ -283,9 +299,22 @@ class CartController extends BaseController
     {
         $cartId = session(SessionKey::CURRENT_USER);
         session()->forget($cartId);
-        $this->cartService->getNewCartSession(cartId: $cartId);
+        session()->put(SessionKey::CURRENT_USER, $cartId);
+        $cartNames = session(SessionKey::CART_NAME) ?? [];
+        if (!in_array($cartId, $cartNames)) {
+            $cartNames[] = $cartId;
+            session()->put(SessionKey::CART_NAME, $cartNames);
+        }
         $getCurrentCustomerData = $this->getCustomerDataFromSessionForPOS();
-        $summaryData = array_merge($this->POSService->getSummaryData(), $getCurrentCustomerData);
+        $cartNames = session(SessionKey::CART_NAME) ?? [];
+        $allCarts = [];
+        foreach ($cartNames as $name) {
+            $allCarts[$name] = session($name);
+        }
+        $summaryData = array_merge(
+            $this->POSService->getSummaryData(carts: $allCarts, currentUser: session(SessionKey::CURRENT_USER)),
+            $getCurrentCustomerData
+        );
         $cartItems = $this->getCartData(cartName: $cartId);
         return response()->json([
             'view' => view('admin-views.pos.partials._cart-summary', compact('summaryData', 'cartItems'))->render(),
@@ -298,9 +327,13 @@ class CartController extends BaseController
      */
     public function changeCart(Request $request): RedirectResponse
     {
-        $this->cartService->customerOnHoldStatus(status: true);
+        $cart = session(session(SessionKey::CURRENT_USER), []);
+        $cart = $this->cartService->customerOnHoldStatus(cart: $cart, status: true);
+        session()->put(session(SessionKey::CURRENT_USER), $cart);
         session()->put(SessionKey::CURRENT_USER, $request['cart_id']);
-        $this->cartService->customerOnHoldStatus(status: false);
+        $cart = session($request['cart_id'], []);
+        $cart = $this->cartService->customerOnHoldStatus(cart: $cart, status: false);
+        session()->put($request['cart_id'], $cart);
         ToastMagic::success($request['cart_id'] . ' ' . translate('order_is_now_resumed'));
         return redirect()->route('admin.pos.index');
     }
@@ -314,8 +347,16 @@ class CartController extends BaseController
         if (session()->has(session(SessionKey::CURRENT_USER)) && count($cart) > 0) {
             ToastMagic::success(translate('this_order_is_now_on_hold'));
         }
-        $this->cartService->customerOnHoldStatus(status: true);
-        $this->cartService->getNewCartId();
+        $cart = session(session(SessionKey::CURRENT_USER), []);
+        $cart = $this->cartService->customerOnHoldStatus(cart: $cart, status: true);
+        session()->put(session(SessionKey::CURRENT_USER), $cart);
+        $cartId = 'walk-in-customer-' . rand(10, 1000);
+        session()->put(SessionKey::CURRENT_USER, $cartId);
+        $cartNames = session(SessionKey::CART_NAME) ?? [];
+        if (!in_array($cartId, $cartNames)) {
+            $cartNames[] = $cartId;
+            session()->put(SessionKey::CART_NAME, $cartNames);
+        }
         return redirect()->route('admin.pos.index');
     }
 
@@ -411,8 +452,10 @@ class CartController extends BaseController
                 }
             }
         }
+        $cart = session()->get($cartName, []);
         $totalCalculation = $this->cartService->getTotalCalculation(
-            subTotalCalculation: $subTotalCalculation, cartName: $cartName
+            subTotalCalculation: $subTotalCalculation,
+            cart: $cart
         );
         return [
             'countItem' => $subTotalCalculation['countItem'],

--- a/app/Http/Controllers/Vendor/POS/POSController.php
+++ b/app/Http/Controllers/Vendor/POS/POSController.php
@@ -67,7 +67,7 @@ class POSController extends BaseController
      * @param string|null $type
      * @return View|Collection|LengthAwarePaginator|callable|RedirectResponse|null
      */
-    public function index(?Request $request, string $type = null): View|Collection|LengthAwarePaginator|null|callable|RedirectResponse
+    public function index(?Request $request, ?string $type = null): View|Collection|LengthAwarePaginator|null|callable|RedirectResponse
     {
         return $this->getPOSView(request: $request);
     }
@@ -105,10 +105,22 @@ class POSController extends BaseController
             dataLimit: getWebConfig('pagination_limit'),
         );
         $cartId = 'walk-in-customer-' . rand(10, 1000);
-        $this->cartService->getNewCartSession(cartId: $cartId);
+        session()->put(SessionKey::CURRENT_USER, $cartId);
+        $cartNames = session(SessionKey::CART_NAME) ?? [];
+        if (!in_array($cartId, $cartNames)) {
+            $cartNames[] = $cartId;
+            session()->put(SessionKey::CART_NAME, $cartNames);
+        }
         $customers = $this->customerRepo->getListWhereNotIn(ids: [0]);
         $getCurrentCustomerData = $this->getCustomerDataFromSessionForPOS();
-        $summaryData = array_merge($this->POSService->getSummaryData(), $getCurrentCustomerData);
+        $allCarts = [];
+        foreach ($cartNames as $name) {
+            $allCarts[$name] = session($name);
+        }
+        $summaryData = array_merge(
+            $this->POSService->getSummaryData(carts: $allCarts, currentUser: session(SessionKey::CURRENT_USER)),
+            $getCurrentCustomerData
+        );
         $cartItems = $this->getCartData(cartName: session(SessionKey::CURRENT_USER));
         $order = $this->orderRepo->getFirstWhere(params: ['id' => session(SessionKey::LAST_ORDER)]);
         $totalHoldOrder = $summaryData['totalHoldOrders'];
@@ -138,9 +150,21 @@ class POSController extends BaseController
     public function changeCustomer(Request $request): JsonResponse
     {
         $cartId = ($request['user_id'] != 0 ? 'saved-customer-' . $request['user_id'] : 'walk-in-customer-' . rand(10, 1000));
-        $this->POSService->UpdateSessionWhenCustomerChange(cartId: $cartId);
+        session()->put(SessionKey::CURRENT_USER, $cartId);
+        $cartNames = session(SessionKey::CART_NAME) ?? [];
+        if (!in_array($cartId, $cartNames)) {
+            $cartNames[] = $cartId;
+            session()->put(SessionKey::CART_NAME, $cartNames);
+        }
         $getCurrentCustomerData = $this->getCustomerDataFromSessionForPOS();
-        $summaryData = array_merge($this->POSService->getSummaryData(), $getCurrentCustomerData);
+        $allCarts = [];
+        foreach ($cartNames as $name) {
+            $allCarts[$name] = session($name);
+        }
+        $summaryData = array_merge(
+            $this->POSService->getSummaryData(carts: $allCarts, currentUser: $cartId),
+            $getCurrentCustomerData
+        );
         $cartItems = $this->getCartData(cartName: $cartId);
 
         return response()->json([
@@ -279,7 +303,7 @@ class POSController extends BaseController
                     }
                 }
                 if ($totalProductPrice >= $coupon['min_purchase']) {
-                    $calculation = $this->POSService->getCouponCalculation(coupon: $coupon, totalProductPrice: $totalProductPrice, productDiscount: $productDiscount, productTax: $productTax);
+                    $calculation = $this->POSService->getCouponCalculation(coupon: $coupon, totalProductPrice: $totalProductPrice, productDiscount: $productDiscount, productTax: $productTax, cart: $carts);
                     $couponDiscount = $calculation['discount'];
 
                     $extraDiscount = 0;
@@ -301,13 +325,14 @@ class POSController extends BaseController
                         ]);
                     }
 
-                    $this->POSService->putCouponDataOnSession(
-                        cartId: $cartId,
+                    $carts = $this->POSService->applyCouponToCart(
+                        cart: $carts,
                         discount: $couponDiscount,
                         couponTitle: $coupon['title'],
                         couponBearer: $coupon['coupon_bearer'],
                         couponCode: $request['coupon_code']
                     );
+                    session()->put($cartId, $carts);
                     $cartItems = $this->getCartData(cartName: $cartId);
                     return response()->json([
                         'coupon' => 'success',
@@ -438,8 +463,10 @@ class POSController extends BaseController
                 }
             }
         }
+        $cart = session()->get($cartName, []);
         $totalCalculation = $this->cartService->getTotalCalculation(
-            subTotalCalculation: $subTotalCalculation, cartName: $cartName
+            subTotalCalculation: $subTotalCalculation,
+            cart: $cart
         );
         return [
             'countItem' => $subTotalCalculation['countItem'],


### PR DESCRIPTION
## Summary
- Decouple POSService from session by passing cart arrays and adding `applyCouponToCart`
- Compute totals and hold status in CartService using provided cart arrays
- Update POS and cart controllers to manage sessions and supply explicit cart data

## Testing
- `composer install --no-interaction --no-progress --no-scripts` *(fails: package php version/ext requirements)*


------
https://chatgpt.com/codex/tasks/task_e_68a36006500483268a1f4f7e77cf2918