### PR TITLE
feat: add dedicated POS add to cart button

### DIFF
--- a/public/assets/back-end/js/admin/pos-script.js
+++ b/public/assets/back-end/js/admin/pos-script.js
@@ -191,6 +191,7 @@ function renderSelectProduct() {
     });
 
     $(".action-add-to-cart").on("click", function (e) {
+        e.stopPropagation();
         addToCart();
     });
 

--- a/public/assets/back-end/js/vendor/pos-script.js
+++ b/public/assets/back-end/js/vendor/pos-script.js
@@ -179,7 +179,8 @@ function renderSelectProduct() {
         getVariantForAlreadyInCart($(this).data("action"));
     });
 
-    $(".action-add-to-cart").on("click", function () {
+    $(".action-add-to-cart").on("click", function (e) {
+        e.stopPropagation();
         addToCart();
     });
 

--- a/resources/views/admin-views/pos/partials/_single-product.blade.php
+++ b/resources/views/admin-views/pos/partials/_single-product.blade.php
@@ -23,5 +23,16 @@
                 </span>
             </div>
         </div>
+        <div class="mt-2">
+            <button type="button"
+                    class="btn btn-primary btn-block action-add-to-cart"
+                    data-id="{{ $product['id'] }}"
+                    data-name="{{ $product['name'] }}"
+                    data-price="{{ getProductPriceByType(product: $product, type: 'discounted_unit_price', result: 'value', price: $product['unit_price'], from: 'panel') }}"
+                    data-default-variant="{{ $product['default_variant'] ?? '' }}"
+                    data-stock="{{ $product['current_stock'] }}">
+                {{ translate('add_to_cart') }}
+            </button>
+        </div>
     </div>
 </div>

--- a/resources/views/vendor-views/pos/partials/_single-product.blade.php
+++ b/resources/views/vendor-views/pos/partials/_single-product.blade.php
@@ -23,5 +23,16 @@
                 </span>
             </div>
         </div>
+        <div class="mt-2">
+            <button type="button"
+                    class="btn btn--primary btn-block action-add-to-cart"
+                    data-id="{{ $product['id'] }}"
+                    data-name="{{ $product['name'] }}"
+                    data-price="{{ getProductPriceByType(product: $product, type: 'discounted_unit_price', result: 'value', price: $product['unit_price'], from: 'panel') }}"
+                    data-default-variant="{{ $product['default_variant'] ?? '' }}"
+                    data-stock="{{ $product['current_stock'] }}">
+                {{ translate('add_to_cart') }}
+            </button>
+        </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- add Add to Cart buttons on admin & vendor POS product cards with product info data attributes
- prevent quick view from firing when Add to Cart button is clicked

## Testing
- `phpunit` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a37249fdd48326808583cfc79dd823