### PR TITLE
Move cart data to client-side JSON

### DIFF
--- a/app/Http/Controllers/Vendor/POS/POSOrderController.php
+++ b/app/Http/Controllers/Vendor/POS/POSOrderController.php
@@ -9,7 +9,6 @@ use App\Contracts\Repositories\OrderRepositoryInterface;
 use App\Contracts\Repositories\ProductRepositoryInterface;
 use App\Contracts\Repositories\StorageRepositoryInterface;
 use App\Contracts\Repositories\VendorRepositoryInterface;
-use App\Enums\SessionKey;
 use App\Enums\ViewPaths\Vendor\POSOrder;
 use App\Events\DigitalProductDownloadEvent;
 use App\Http\Controllers\BaseController;
@@ -101,6 +100,9 @@ class POSOrderController extends BaseController
         $cityId = $request['city_id'] ?? null;
 
         $cart = $request->input('cart', []);
+        if (is_string($cart)) {
+            $cart = json_decode($cart, true) ?: [];
+        }
         $cartItems = $cart['items'] ?? [];
         if (empty($cartItems)) {
             ToastMagic::error(translate('cart_empty_warning'));

--- a/public/assets/back-end/js/admin/pos-script.js
+++ b/public/assets/back-end/js/admin/pos-script.js
@@ -355,6 +355,7 @@ function basicFunctionalityForCartSummary() {
                 reverseButtons: true,
             }).then(function (result) {
                 if (result.value) {
+                    document.querySelector('input[name="cart"]').value = JSON.stringify({items: cart});
                     let formData = new FormData(
                         document.getElementById("order-place")
                     );

--- a/public/assets/back-end/js/vendor/pos-script.js
+++ b/public/assets/back-end/js/vendor/pos-script.js
@@ -322,6 +322,7 @@ function basicFunctionalityForCartSummary() {
                 reverseButtons: true,
             }).then(function (result) {
                 if (result.value) {
+                    document.querySelector('input[name="cart"]').value = JSON.stringify({items: cart});
                     let formData = new FormData(document.getElementById('order-place'));
                     $.ajaxSetup({
                         headers: {

--- a/resources/views/admin-views/pos/partials/_cart.blade.php
+++ b/resources/views/admin-views/pos/partials/_cart.blade.php
@@ -2,7 +2,7 @@
     @csrf
     <input type="hidden" name="city_id" value="{{ session('selected_city_id') }}">
     <input type="hidden" name="seller_id" value="{{ session('selected_seller_id') }}">
-    <input type="hidden" name="cart" value='@json(["items" => $cartItems["cartItemValue"]])'>
+    <input type="hidden" name="cart">
     <div id="cart">
         <div class="table-responsive pos-cart-table border">
             <table class="table table-align-middle m-0">

--- a/resources/views/vendor-views/pos/partials/_cart.blade.php
+++ b/resources/views/vendor-views/pos/partials/_cart.blade.php
@@ -1,6 +1,6 @@
 <form action="{{route('vendor.pos.order-place')}}" id='order-place' method="post" >
     @csrf
-    <input type="hidden" name="cart" value='@json(["items" => $cartItems["cartItemValue"]])'>
+    <input type="hidden" name="cart">
     <div id="cart">
         <div class="table-responsive pos-cart-table border">
             <table class="table table-align-middle m-0">


### PR DESCRIPTION
## Summary
- Drop server-side cart JSON injection for POS forms
- Serialize local cart into hidden field before submitting
- Parse JSON cart data in vendor POS order placement

## Testing
- `composer test` *(fails: Command "test" is not defined)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a3764da4a8832696682a70406d7c45