### PR TITLE
Fix POS add-to-cart validation and hover overlay

### DIFF
--- a/public/assets/back-end/css/style.css
+++ b/public/assets/back-end/css/style.css
@@ -1651,6 +1651,7 @@ img {
   transition: all 0.3s ease;
   opacity: 0;
   visibility: hidden;
+  pointer-events: none;
 }
 
 .pos-product-item:hover .pos-product-item_hover-content {

--- a/public/assets/back-end/css/style.scss
+++ b/public/assets/back-end/css/style.scss
@@ -1693,6 +1693,7 @@ img {
     transition: all 0.3s ease;
     opacity: 0;
     visibility: hidden;
+    pointer-events: none;
 }
 
 .pos-product-item:hover .pos-product-item_hover-content {

--- a/public/assets/back-end/js/admin/pos-script.js
+++ b/public/assets/back-end/js/admin/pos-script.js
@@ -777,19 +777,14 @@ function getVariantForAlreadyInCart(event = null) {
 }
 
 function checkAddToCartValidity() {
-    var names = {};
-    $("#add-to-cart-form input:radio").each(function () {
+    const form = $("#add-to-cart-form");
+    const names = {};
+    form.find("input:radio").each(function () {
         names[$(this).attr("name")] = true;
     });
-    var count = 0;
-    $.each(names, function () {
-        count++;
-    });
-
-    if ($("input:radio:checked").length - 1 == count) {
-        return true;
-    }
-    return false;
+    const totalGroups = Object.keys(names).length;
+    const selected = form.find("input:radio:checked").length;
+    return selected === totalGroups;
 }
 
 function cartQuantityInitialize() {

--- a/public/assets/back-end/js/vendor/pos-script.js
+++ b/public/assets/back-end/js/vendor/pos-script.js
@@ -715,19 +715,14 @@ function getVariantForAlreadyInCart(event = null) {
 }
 
 function checkAddToCartValidity() {
-    var names = {};
-    $("#add-to-cart-form input:radio").each(function () {
+    const form = $("#add-to-cart-form");
+    const names = {};
+    form.find("input:radio").each(function () {
         names[$(this).attr("name")] = true;
     });
-    var count = 0;
-    $.each(names, function () {
-        count++;
-    });
-
-    if ($("input:radio:checked").length - 1 == count) {
-        return true;
-    }
-    return false;
+    const totalGroups = Object.keys(names).length;
+    const selected = form.find("input:radio:checked").length;
+    return selected === totalGroups;
 }
 
 function cartQuantityInitialize() {

--- a/public/assets/new/back-end/css/style.css
+++ b/public/assets/new/back-end/css/style.css
@@ -1111,6 +1111,7 @@ code.hljs {
   transition: all 0.3sease;
   opacity: 0;
   visibility: hidden;
+  pointer-events: none;
 }
 
 .pos-product-item:hover .pos-product-item_hover-content {

--- a/public/assets/new/back-end/css/style.scss
+++ b/public/assets/new/back-end/css/style.scss
@@ -1094,6 +1094,7 @@ $size: 50px;
     transition: all 0.3sease;
     opacity: 0;
     visibility: hidden;
+    pointer-events: none;
 }
 .pos-product-item:hover .pos-product-item_hover-content {
     opacity: 1;


### PR DESCRIPTION
## Summary
- allow adding products without variations to POS cart
- prevent hover overlay from blocking product interactions

## Testing
- `composer install --ignore-platform-req=ext-sodium --ignore-platform-req=php` *(fails: requires GitHub token)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a37a6904988326bf153ccc6a2191a3